### PR TITLE
Remove log volume from docker-compose, use stdout logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,6 @@ services:
       SYNC_INTERVAL_MINUTES: ${SYNC_INTERVAL_MINUTES:-15}
       ENVIRONMENT: ${ENVIRONMENT:-production}
       MAX_REQUESTS_PER_MINUTE: ${MAX_REQUESTS_PER_MINUTE:-60}
-    volumes:
-      - app_logs:/app/logs
     networks:
       - whoopster-network
     healthcheck:
@@ -98,8 +96,6 @@ volumes:
   postgres_data:
     driver: local
   grafana_data:
-    driver: local
-  app_logs:
     driver: local
 
 networks:


### PR DESCRIPTION
## Summary

Removed the `app_logs` volume mount and volume definition from docker-compose.yml to follow Docker best practices for logging.

## Changes

- ✅ Removed `app_logs` volume mount from app service
- ✅ Removed `app_logs` volume definition from volumes section
- ✅ All logging already configured to stdout via `StreamHandler` in `src/utils/logging_config.py:34`

## Benefits

- **Follows 12-factor app methodology**: Logs treated as event streams to stdout
- **Better log management**: Docker handles log aggregation and rotation through logging drivers
- **Simplified deployment**: No need to manage log volumes
- **Standard tooling**: Use `docker logs whoopster-app` or `docker-compose logs app`

## Testing

The application logging configuration in `src/utils/logging_config.py` already uses:
```python
console_handler = logging.StreamHandler(sys.stdout)
```

This means all logs are sent to stdout/stderr, which Docker captures automatically.

## Breaking Changes

None - logs are still accessible, just through Docker's logging system instead of a mounted volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)