### PR TITLE
Fix: Allow Docker deployments without .env file

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,15 +12,11 @@ from dotenv import load_dotenv
 PROJECT_ROOT = Path(__file__).parent.parent
 ENV_FILE = PROJECT_ROOT / ".env"
 
-# Load .env file explicitly using python-dotenv
+# Load .env file explicitly using python-dotenv if it exists
 # This ensures the file is loaded regardless of current working directory
+# In Docker/production, environment variables can be passed directly without a .env file
 if ENV_FILE.exists():
     load_dotenv(ENV_FILE)
-else:
-    raise FileNotFoundError(
-        f"Missing .env file at {ENV_FILE}. "
-        f"Please copy .env.example to .env and configure your settings."
-    )
 
 
 class Settings(BaseSettings):
@@ -130,8 +126,14 @@ def _initialize_settings() -> Settings:
                 error_lines.append(f"  - {item['field']}: {item['error']}")
 
         error_lines.extend([
-            f"\nPlease update your .env file at: {ENV_FILE}",
+            f"\nPlease set these environment variables in your .env file or Docker environment.",
+            f"For local development, create .env at: {ENV_FILE}",
             f"You can use .env.example as a template: {PROJECT_ROOT / '.env.example'}",
+            "",
+            "For Docker/production, pass these as environment variables via:",
+            "  - docker-compose.yml (environment section)",
+            "  - docker run -e VARIABLE=value",
+            "  - Kubernetes secrets/configmaps",
             "",
             "For TOKEN_ENCRYPTION_KEY, generate a new key with:",
             "  python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"",


### PR DESCRIPTION
## Summary

Fixed the configuration to allow Docker deployments without requiring a `.env` file. Environment variables can now be passed directly via docker-compose.yml or docker run.

## Problem

The application was throwing this error when deployed in Docker:
```
FileNotFoundError: Missing .env file at /app/.env. Please copy .env.example to .env and configure your settings.
```

This happened because `src/config.py` required a `.env` file to exist, even though environment variables were being passed correctly through Docker.

## Solution

- **Removed `.env` file requirement**: The file is now optional and only loaded if it exists
- **Updated error messages**: Added Docker-specific instructions for missing environment variables
- **Supports both deployment methods**:
  - Local development: Uses `.env` file if present
  - Docker/production: Uses environment variables from docker-compose.yml or docker run

## Changes

**src/config.py:**
- Removed `FileNotFoundError` when `.env` file doesn't exist
- Added Docker-friendly error messages with examples
- Maintained backward compatibility for local development

## Testing

After this change, Docker deployments work with:

```yaml
# docker-compose.yml
environment:
  POSTGRES_PASSWORD: secret
  WHOOP_CLIENT_ID: your_client_id
  # ... other env vars
```

Or with docker run:
```bash
docker run -e POSTGRES_PASSWORD=secret -e WHOOP_CLIENT_ID=your_id whoopster
```

## Breaking Changes

None - `.env` files still work for local development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)