### PR TITLE
Remove unused Grafana admin credentials from app config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -61,10 +61,6 @@ class Settings(BaseSettings):
     # Rate Limiting
     max_requests_per_minute: int = 60
 
-    # Grafana Configuration
-    grafana_admin_user: str = "admin"
-    grafana_admin_password: str
-
     # Security Configuration
     token_encryption_key: str  # Required: Fernet encryption key for OAuth tokens
 


### PR DESCRIPTION
## Summary

Removed `grafana_admin_user` and `grafana_admin_password` from the whoopster application configuration since these variables are only used by the Grafana container, not by the whoopster application itself.

## Problem

The application was requiring `GRAFANA_ADMIN_PASSWORD` to be set, causing this error:
```
CONFIGURATION ERROR: Missing or invalid environment variables

Missing required environment variables:
  - GRAFANA_ADMIN_PASSWORD
```

However, the whoopster application doesn't interact with Grafana's admin credentials at all. These are only needed by the Grafana container for its own authentication.

## Solution

**Removed from `src/config.py`:**
- `grafana_admin_user: str = "admin"` 
- `grafana_admin_password: str`

These settings are only used in `docker-compose.yml` for the Grafana container's environment variables, not by the whoopster application code.

## Verification

Searched the codebase to confirm the whoopster app doesn't use these variables:
```bash
grep -r "grafana_admin" src/ --include="*.py" | grep -v config.py
# No results - not used anywhere in the app
```

## Required Environment Variables (After This Fix)

The whoopster app now only requires these environment variables:
- `POSTGRES_PASSWORD`
- `POSTGRES_HOST` (defaults to "postgres")
- `POSTGRES_DB` (defaults to "whoopster")
- `POSTGRES_USER` (defaults to "whoopster")
- `POSTGRES_PORT` (defaults to 5432)
- `WHOOP_CLIENT_ID`
- `WHOOP_CLIENT_SECRET`
- `TOKEN_ENCRYPTION_KEY`

Grafana's admin credentials are still required if you're running Grafana, but they're set on the Grafana container, not the whoopster container.

## Breaking Changes

None - this only removes unused configuration requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)