### PR TITLE
test: fix respx v1→v2 URLs and async scheduler tests

### DIFF
--- a/tests/integration/test_data_sync.py
+++ b/tests/integration/test_data_sync.py
@@ -41,7 +41,7 @@ class TestDataSyncIntegration:
             # Mock rate limiter
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
                 # Mock API response
-                respx.get(f"{client.base_url}/developer/v1/activity/sleep").mock(
+                respx.get(f"{client.base_url}/developer/v2/activity/sleep").mock(
                     return_value=httpx.Response(200, json=mock_whoop_sleep_response)
                 )
 
@@ -106,7 +106,7 @@ class TestDataSyncIntegration:
                     mock_context.return_value.__exit__ = mock_exit
 
                     # First sync - return response with 80.0
-                    route = respx.get(f"{client.base_url}/developer/v1/activity/sleep")
+                    route = respx.get(f"{client.base_url}/developer/v2/activity/sleep")
                     route.mock(return_value=httpx.Response(200, json=mock_whoop_sleep_response))
 
                     await service.sync_sleep_records()
@@ -152,16 +152,16 @@ class TestDataSyncIntegration:
         ):
             with patch.object(collector.rate_limiter, "acquire", new=AsyncMock()):
                 # Mock all API endpoints
-                respx.get(f"{collector.whoop_client.base_url}/developer/v1/activity/sleep").mock(
+                respx.get(f"{collector.whoop_client.base_url}/developer/v2/activity/sleep").mock(
                     return_value=httpx.Response(200, json=mock_whoop_sleep_response)
                 )
-                respx.get(f"{collector.whoop_client.base_url}/developer/v1/recovery").mock(
+                respx.get(f"{collector.whoop_client.base_url}/developer/v2/recovery").mock(
                     return_value=httpx.Response(200, json=mock_whoop_recovery_response)
                 )
-                respx.get(f"{collector.whoop_client.base_url}/developer/v1/activity/workout").mock(
+                respx.get(f"{collector.whoop_client.base_url}/developer/v2/activity/workout").mock(
                     return_value=httpx.Response(200, json=mock_whoop_workout_response)
                 )
-                respx.get(f"{collector.whoop_client.base_url}/developer/v1/cycle").mock(
+                respx.get(f"{collector.whoop_client.base_url}/developer/v2/cycle").mock(
                     return_value=httpx.Response(200, json=mock_whoop_cycle_response)
                 )
 
@@ -220,7 +220,7 @@ class TestDataSyncIntegration:
             new=AsyncMock(return_value=test_oauth_token.access_token),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                route = respx.get(f"{client.base_url}/developer/v1/activity/sleep")
+                route = respx.get(f"{client.base_url}/developer/v2/activity/sleep")
                 route.mock(
                     return_value=httpx.Response(200, json=mock_whoop_sleep_response)
                 )
@@ -254,7 +254,7 @@ class TestDataSyncIntegration:
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
                 # Mock API error
-                respx.get(f"{client.base_url}/developer/v1/activity/sleep").mock(
+                respx.get(f"{client.base_url}/developer/v2/activity/sleep").mock(
                     return_value=httpx.Response(500, json={"error": "Internal server error"})
                 )
 
@@ -345,7 +345,7 @@ class TestDataSyncIntegration:
             new=AsyncMock(return_value=test_oauth_token.access_token),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                route = respx.get(f"{client.base_url}/developer/v1/activity/sleep")
+                route = respx.get(f"{client.base_url}/developer/v2/activity/sleep")
                 route.side_effect = [
                     httpx.Response(200, json=page1),
                     httpx.Response(200, json=page2),

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -124,7 +124,7 @@ class TestWhoopSchedulerAsync:
             # Cleanup
             scheduler.scheduler.remove_job(f"sync_user_{test_user.id}")
 
-    def test_start_scheduler(self):
+    async def test_start_scheduler(self):
         """Test starting the scheduler."""
         scheduler = WhoopScheduler(use_persistent_jobstore=False)
 
@@ -135,7 +135,7 @@ class TestWhoopSchedulerAsync:
         # Cleanup
         scheduler.shutdown(wait=False)
 
-    def test_start_scheduler_already_running(self):
+    async def test_start_scheduler_already_running(self):
         """Test starting scheduler when already running."""
         scheduler = WhoopScheduler(use_persistent_jobstore=False)
 
@@ -148,15 +148,13 @@ class TestWhoopSchedulerAsync:
         # Cleanup
         scheduler.shutdown(wait=False)
 
-    def test_shutdown_scheduler(self):
+    async def test_shutdown_scheduler(self):
         """Test shutting down the scheduler."""
         scheduler = WhoopScheduler(use_persistent_jobstore=False)
 
         scheduler.start()
         assert scheduler.scheduler.running is True
 
-        # Shutdown should complete without error
-        # Note: AsyncIOScheduler may not fully stop when called from sync context
         scheduler.shutdown(wait=True)
 
     def test_shutdown_scheduler_not_running(self):

--- a/tests/unit/test_whoop_client.py
+++ b/tests/unit/test_whoop_client.py
@@ -127,7 +127,7 @@ class TestWhoopClientAsync:
             new=AsyncMock(return_value="test_token"),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                respx.get(f"{client.base_url}/developer/v1/activity/sleep").mock(
+                respx.get(f"{client.base_url}/developer/v2/activity/sleep").mock(
                     return_value=httpx.Response(200, json=mock_whoop_sleep_response)
                 )
 
@@ -147,7 +147,7 @@ class TestWhoopClientAsync:
             new=AsyncMock(return_value="test_token"),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                respx.get(f"{client.base_url}/developer/v1/activity/workout").mock(
+                respx.get(f"{client.base_url}/developer/v2/activity/workout").mock(
                     return_value=httpx.Response(200, json=mock_whoop_workout_response)
                 )
 
@@ -167,7 +167,7 @@ class TestWhoopClientAsync:
             new=AsyncMock(return_value="test_token"),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                respx.get(f"{client.base_url}/developer/v1/recovery").mock(
+                respx.get(f"{client.base_url}/developer/v2/recovery").mock(
                     return_value=httpx.Response(200, json=mock_whoop_recovery_response)
                 )
 
@@ -187,7 +187,7 @@ class TestWhoopClientAsync:
             new=AsyncMock(return_value="test_token"),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                respx.get(f"{client.base_url}/developer/v1/cycle").mock(
+                respx.get(f"{client.base_url}/developer/v2/cycle").mock(
                     return_value=httpx.Response(200, json=mock_whoop_cycle_response)
                 )
 
@@ -206,7 +206,7 @@ class TestWhoopClientAsync:
             new=AsyncMock(return_value="test_token"),
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
-                respx.get(f"{client.base_url}/developer/v1/user/profile/basic").mock(
+                respx.get(f"{client.base_url}/developer/v2/user/profile/basic").mock(
                     return_value=httpx.Response(200, json=mock_whoop_user_profile)
                 )
 
@@ -239,7 +239,7 @@ class TestWhoopClientAsync:
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
                 # Mock paginated responses
-                route = respx.get(f"{client.base_url}/developer/v1/activity/sleep")
+                route = respx.get(f"{client.base_url}/developer/v2/activity/sleep")
                 route.side_effect = [
                     httpx.Response(200, json=page1),
                     httpx.Response(200, json=page2),
@@ -265,7 +265,7 @@ class TestWhoopClientAsync:
         ):
             with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
                 mock_response = {"records": [], "next_token": None}
-                route = respx.get(f"{client.base_url}/developer/v1/activity/sleep")
+                route = respx.get(f"{client.base_url}/developer/v2/activity/sleep")
                 route.mock(return_value=httpx.Response(200, json=mock_response))
 
                 await client.get_sleep_records(start=start, end=end)


### PR DESCRIPTION
## Summary
- All `respx`-based tests in `tests/unit/test_whoop_client.py` and `tests/integration/test_data_sync.py` mocked the legacy `/developer/v1/*` URLs, but `src/api/whoop_client.py` already calls `/developer/v2/*`. Every PR (Renovate, Dependabot, manual) inherited the `AllMockedAssertionError` failure from `main`.
- Three `WhoopScheduler` tests in `tests/unit/test_scheduler.py` (`test_start_scheduler`, `test_start_scheduler_already_running`, `test_shutdown_scheduler`) were sync methods inside an `@pytest.mark.asyncio` class. On Python 3.14, `AsyncIOScheduler.start()` raises `RuntimeError: no running event loop` when invoked outside a running loop. Converting these tests to `async def` gives them the loop their class is already designed around.

## Test plan
- [x] `pytest tests/ -v --tb=short` — 132 passed, 1 skipped (pre-existing PostgreSQL-only test), 0 failures.
- [ ] CI `Test` workflow goes green on this PR.

## Notes
- This unblocks all 10 open dep-bump PRs, which were all failing on these same pre-existing test bugs.
- No source code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)