### PR TITLE
fix(docker): use absolute venv paths in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ USER whoopster
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
     CMD python -c "import sys; from src.config import settings; sys.exit(0)"
 
-CMD ["sh", "-c", "alembic upgrade head && python -m src.main"]
+CMD ["sh", "-c", "/app/.venv/bin/alembic upgrade head && /app/.venv/bin/python -m src.main"]


### PR DESCRIPTION
## Summary
- After #61, the runtime container restart-loops with `sh: 1: alembic: not found` on deployment platforms that don't propagate the image's `ENV PATH` to the CMD's shell.
- Root cause: `uv sync` installs binaries to `/app/.venv/bin/`, which is only on `PATH` via the image's `ENV PATH="/app/.venv/bin:$PATH"`. The old pip-based image installed to `/usr/local/bin/`, which is on every shell's default PATH.
- Fix: invoke `alembic` and `python` by absolute path in `CMD` so startup doesn't depend on `PATH` inheritance.

## Reproduction
Running the current image with a stripped PATH reproduces the production error exactly:
```
$ docker run --rm --entrypoint sh -e PATH=/usr/bin:/bin <image> -c "alembic upgrade head"
sh: 1: alembic: not found
```
With the fix:
```
$ docker run --rm --entrypoint sh -e PATH=/usr/bin:/bin <image> -c "/app/.venv/bin/alembic --version"
alembic 1.18.4
```

## Test plan
- [x] `docker build .` succeeds
- [x] `/app/.venv/bin/alembic --version` runs inside the image with a minimal PATH
- [x] `/app/.venv/bin/python --version` runs inside the image with a minimal PATH
- [ ] Redeploy and confirm the restart loop clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)