### PR TITLE
chore: add weekly GHCR retention workflow

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,38 @@
+name: GHCR retention
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  prune:
+    name: Prune old GHCR versions
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Prune from the full version pool, but preserve `latest`.
+      # Always keeps the 5 most recent versions regardless of tag, so the
+      # last 5 sha-* tagged builds survive for rollback.
+      - name: Prune tagged + untagged (keep latest + last 5)
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: '^latest$'
+
+      # Step 2: Explicit cleanup of untagged versions (build cache layers,
+      # orphaned manifests). Keeps the 5 most recent untagged for safety.
+      - name: Prune untagged only (keep last 5 untagged)
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          min-versions-to-keep: 5
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
## Summary
Adds a weekly GHCR retention workflow that:
- Keeps the `latest` tag
- Always keeps the 5 most recent versions regardless of tag (preserves the last 5 `sha-*` builds for rollback)
- Prunes older `sha-*` tagged versions beyond that
- Separately prunes untagged versions (build cache layers, orphans), keeping the last 5 untagged for safety

## Schedule
- `schedule`: Mondays 06:00 UTC
- `workflow_dispatch`: manual button — **run this once after merge** to perform the initial cleanup of pre-supply-chain images

## Why
After landing supply-chain gates + cosign signing + SBOM/provenance attestations, old unsigned images still sit in GHCR. This workflow cleans them out and prevents the pile from growing.

## No semver preservation
This repo doesn't tag releases with `v*` git tags, so no semver image tags exist. The retention regex only preserves `latest` (verified via GHCR API).

## Permissions
Uses `GITHUB_TOKEN` with `packages: write` (granted in the workflow's `permissions:` block). No PATs.

## Action used
[`actions/delete-package-versions@v5`](https://github.com/actions/delete-package-versions) (official GitHub action). Both steps use `continue-on-error: true` so a transient registry hiccup in one step doesn't fail the whole workflow.

## Test plan
- [ ] After merge: click "Run workflow" in Actions tab to do the one-time cleanup
- [ ] Verify in the Packages tab that `latest` + last 5 `sha-*` tags remain; older versions are gone
- [ ] Next Monday: confirm the scheduled run executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)