### PR TITLE
fix: bundle tzdata for distroless runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "structlog==25.5.0",
     "python-json-logger==4.1.0",
     "python-dotenv==1.2.2",
+    "tzdata>=2026.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -708,6 +708,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "tzdata" },
 ]
 
 [package.dev-dependencies]
@@ -737,6 +738,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "structlog", specifier = "==25.5.0" },
     { name = "tenacity", specifier = "==9.1.4" },
+    { name = "tzdata", specifier = ">=2026.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Add `tzdata>=2026.2` so Python's stdlib `zoneinfo` can resolve IANA timezones (`America/New_York` etc.) on the Chainguard distroless runtime, which ships no `/usr/share/zoneinfo`.
- Without this, apscheduler fails to add new sync jobs and fails to deserialize pickled triggers from the SQLAlchemy jobstore, throwing `ZoneInfoNotFoundError` / `ModuleNotFoundError: No module named 'tzdata'`.

## Why `>=` instead of `==`
`uv.lock` provides reproducibility regardless of the specifier shape (`uv sync --frozen` is what the Dockerfile and CI use). `tzdata` is pure IANA data — append-only, refreshed multiple times a year as governments change DST rules — so floating it upward is desirable; there's no API surface to break. Library deps stay pinned with `==` as before.

## Test plan
- [x] `uv lock` resolves cleanly.
- [x] `.venv/bin/python -c "import zoneinfo; zoneinfo.ZoneInfo('America/New_York')"` succeeds.
- [x] `uv run pytest tests/` — 132 passed, 1 skipped.
- [x] `docker compose build app` — clean.
- [ ] Deploy via Ansible and confirm scheduler adds the sync job for the existing user without `ZoneInfoNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)