### PR TITLE
Expand Whoop capture: sleep debt/linkage + body measurements

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -1,0 +1,50 @@
+# Standalone app-only compose: just the Whoopster container, no bundled
+# Postgres/Grafana. Every setting comes from .env (env_file below), so the
+# connection target is whatever POSTGRES_HOST / POSTGRES_DB / POSTGRES_PORT
+# you set there — e.g. your main `whoop_db`. Nothing is hardcoded.
+#
+# Normal run (migrate + start scheduler):
+#   docker compose -f docker-compose.app.yml up --build
+#
+# One-off OAuth re-auth (interactive, no shell needed):
+#   docker compose -f docker-compose.app.yml run --build --rm -it \
+#     --entrypoint python app /app/scripts/init_oauth.py --headless
+#
+# IMPORTANT: .env must contain POSTGRES_DB=whoop_db (your real database),
+# a POSTGRES_HOST the container can actually reach, and TOKEN_ENCRYPTION_KEY.
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: whoopster:latest
+    container_name: whoopster-app
+    restart: unless-stopped
+    # Pass the entire .env through to the container verbatim — this is what
+    # makes it connect to your main DB instead of a bundled one.
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "from src.database.session import verify_connection; import sys; sys.exit(0 if verify_connection() else 1)"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+    # --- Reaching your Postgres ----------------------------------------------
+    # If your main Postgres is reachable by host/IP from a normal container
+    # (e.g. a published port, host.docker.internal, or a LAN IP in
+    # POSTGRES_HOST), nothing more is needed.
+    #
+    # If it only lives on an existing Docker network (your data showed it at
+    # 172.29.0.15, a Docker-internal address), attach to that network so the
+    # container can reach it — find the name with `docker network ls`:
+    #
+    # networks:
+    #   - whoop_net
+
+# networks:
+#   whoop_net:
+#     external: true
+#     name: <the network your Postgres container is on>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       WHOOP_AUTH_URL: ${WHOOP_AUTH_URL:-https://api.prod.whoop.com/oauth/oauth2/auth}
       WHOOP_TOKEN_URL: ${WHOOP_TOKEN_URL:-https://api.prod.whoop.com/oauth/oauth2/token}
 
+      # Token encryption (Fernet key used to encrypt OAuth tokens at rest)
+      TOKEN_ENCRYPTION_KEY: ${TOKEN_ENCRYPTION_KEY:?TOKEN_ENCRYPTION_KEY must be set}
+
       # Application Configuration
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       SYNC_INTERVAL_MINUTES: ${SYNC_INTERVAL_MINUTES:-15}

--- a/src/api/whoop_client.py
+++ b/src/api/whoop_client.py
@@ -428,3 +428,23 @@ class WhoopClient:
         logger.info("Fetched user profile", user_id=self.user_id)
 
         return response
+
+    async def get_body_measurement(self) -> Dict[str, Any]:
+        """
+        Fetch user body measurements (height, weight, max heart rate).
+
+        Single-object endpoint (no pagination). Requires the
+        read:body_measurement OAuth scope.
+
+        Returns:
+            Body measurement data
+        """
+        endpoint = "/developer/v2/user/measurement/body"
+
+        logger.info("Fetching body measurement", user_id=self.user_id)
+
+        response = await self._make_request(endpoint)
+
+        logger.info("Fetched body measurement", user_id=self.user_id)
+
+        return response

--- a/src/auth/oauth_client.py
+++ b/src/auth/oauth_client.py
@@ -49,6 +49,7 @@ class WhoopOAuthClient:
             "read:workout",
             "read:recovery",
             "read:cycles",
+            "read:body_measurement",  # Height, weight, max heart rate
             "offline",  # For refresh tokens
         ]
 

--- a/src/database/migrations/versions/20260604_1200_a1b2c3d4e5f6_add_sleep_need_disturbance_and_linkage.py
+++ b/src/database/migrations/versions/20260604_1200_a1b2c3d4e5f6_add_sleep_need_disturbance_and_linkage.py
@@ -1,0 +1,127 @@
+"""Add sleep-need/disturbance fields and cycle/sleep linkage IDs
+
+Promotes fields already captured in raw_data into first-class columns and
+wires up the cycle <-> sleep <-> recovery linkage that Whoop API v2 exposes:
+
+- sleep_records: cycle_id, v1_id, in_bed/no_data durations, sleep_cycle_count,
+  disturbance_count, and the sleep-need breakdown (baseline / debt / strain / nap)
+- recovery_records: add sleep_id; change cycle_id from UUID to BIGINT (Whoop
+  sends an integer cycle id, so the old UUID column could never be populated)
+- cycle_records: whoop_cycle_id (the natural integer id, join target)
+
+After adding the columns, this migration backfills every existing row from its
+raw_data JSONB (validated against production data: all casts succeed and every
+recovery row carries cycle_id + sleep_id), so full history is populated, not
+just newly-synced rows. The backfill is Postgres-only (uses JSONB operators);
+the SQLite test schema is built from the models via create_all, not this file.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f00956217044
+Create Date: 2026-06-04 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'f00956217044'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration changes."""
+    # --- sleep_records: linkage + promoted score fields ---
+    op.add_column('sleep_records', sa.Column('cycle_id', sa.BigInteger(), nullable=True))
+    op.add_column('sleep_records', sa.Column('v1_id', sa.BigInteger(), nullable=True))
+    op.add_column('sleep_records', sa.Column('in_bed_duration', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('no_data_duration', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('sleep_cycle_count', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('disturbance_count', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('sleep_needed_baseline', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('sleep_debt', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('sleep_need_from_strain', sa.Integer(), nullable=True))
+    op.add_column('sleep_records', sa.Column('sleep_need_from_nap', sa.Integer(), nullable=True))
+    op.create_index('ix_sleep_records_cycle_id', 'sleep_records', ['cycle_id'])
+
+    # --- recovery_records: add sleep_id, fix cycle_id type (UUID -> BIGINT) ---
+    op.add_column('recovery_records', sa.Column('sleep_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_index('ix_recovery_records_sleep_id', 'recovery_records', ['sleep_id'])
+    # The old UUID cycle_id was never populated (API sends an integer), so we
+    # discard any contents with USING NULL rather than attempting a cast.
+    op.alter_column(
+        'recovery_records',
+        'cycle_id',
+        existing_type=postgresql.UUID(as_uuid=True),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+        postgresql_using='NULL::bigint',
+    )
+
+    # --- cycle_records: natural integer id as join target ---
+    op.add_column('cycle_records', sa.Column('whoop_cycle_id', sa.BigInteger(), nullable=True))
+    op.create_index('ix_cycle_records_whoop_cycle_id', 'cycle_records', ['whoop_cycle_id'])
+
+    # --- Backfill existing rows from raw_data (Postgres JSONB) ---
+    op.execute(
+        """
+        UPDATE sleep_records SET
+            cycle_id = (raw_data->>'cycle_id')::bigint,
+            v1_id = (raw_data->>'v1_id')::bigint,
+            in_bed_duration = (raw_data#>>'{score,stage_summary,total_in_bed_time_milli}')::int,
+            no_data_duration = (raw_data#>>'{score,stage_summary,total_no_data_time_milli}')::int,
+            sleep_cycle_count = (raw_data#>>'{score,stage_summary,sleep_cycle_count}')::int,
+            disturbance_count = (raw_data#>>'{score,stage_summary,disturbance_count}')::int,
+            sleep_needed_baseline = (raw_data#>>'{score,sleep_needed,baseline_milli}')::int,
+            sleep_debt = (raw_data#>>'{score,sleep_needed,need_from_sleep_debt_milli}')::int,
+            sleep_need_from_strain = (raw_data#>>'{score,sleep_needed,need_from_recent_strain_milli}')::int,
+            sleep_need_from_nap = (raw_data#>>'{score,sleep_needed,need_from_recent_nap_milli}')::int
+        WHERE raw_data IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE recovery_records SET
+            cycle_id = (raw_data->>'cycle_id')::bigint,
+            sleep_id = (raw_data->>'sleep_id')::uuid
+        WHERE raw_data IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE cycle_records SET
+            whoop_cycle_id = (raw_data->>'id')::bigint
+        WHERE raw_data IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Revert migration changes."""
+    op.drop_index('ix_cycle_records_whoop_cycle_id', table_name='cycle_records')
+    op.drop_column('cycle_records', 'whoop_cycle_id')
+
+    op.alter_column(
+        'recovery_records',
+        'cycle_id',
+        existing_type=sa.BigInteger(),
+        type_=postgresql.UUID(as_uuid=True),
+        existing_nullable=True,
+        postgresql_using='NULL::uuid',
+    )
+    op.drop_index('ix_recovery_records_sleep_id', table_name='recovery_records')
+    op.drop_column('recovery_records', 'sleep_id')
+
+    op.drop_index('ix_sleep_records_cycle_id', table_name='sleep_records')
+    op.drop_column('sleep_records', 'sleep_need_from_nap')
+    op.drop_column('sleep_records', 'sleep_need_from_strain')
+    op.drop_column('sleep_records', 'sleep_debt')
+    op.drop_column('sleep_records', 'sleep_needed_baseline')
+    op.drop_column('sleep_records', 'disturbance_count')
+    op.drop_column('sleep_records', 'sleep_cycle_count')
+    op.drop_column('sleep_records', 'no_data_duration')
+    op.drop_column('sleep_records', 'in_bed_duration')
+    op.drop_column('sleep_records', 'v1_id')
+    op.drop_column('sleep_records', 'cycle_id')

--- a/src/database/migrations/versions/20260604_1230_b2c3d4e5f6a7_add_body_measurements_table.py
+++ b/src/database/migrations/versions/20260604_1230_b2c3d4e5f6a7_add_body_measurements_table.py
@@ -1,0 +1,46 @@
+"""Add body_measurements table
+
+Time-series storage for Whoop body measurements (height, weight, max heart
+rate). The API exposes only the current value, so the service inserts a new
+row only when a value changes — building a change-history going forward.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-04 12:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6a7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration changes."""
+    op.create_table(
+        'body_measurements',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('height_meter', sa.Numeric(precision=5, scale=3), nullable=True),
+        sa.Column('weight_kilogram', sa.Numeric(precision=6, scale=3), nullable=True),
+        sa.Column('max_heart_rate', sa.Integer(), nullable=True),
+        sa.Column('recorded_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('raw_data', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_body_measurements_user_id', 'body_measurements', ['user_id'])
+    op.create_index('ix_body_measurements_recorded_at', 'body_measurements', ['recorded_at'])
+
+
+def downgrade() -> None:
+    """Revert migration changes."""
+    op.drop_index('ix_body_measurements_recorded_at', table_name='body_measurements')
+    op.drop_index('ix_body_measurements_user_id', table_name='body_measurements')
+    op.drop_table('body_measurements')

--- a/src/models/api_models.py
+++ b/src/models/api_models.py
@@ -41,6 +41,22 @@ class SleepStages(BaseModel):
     slow_wave_sleep_duration_milli: int
     rem_sleep_duration_milli: int
     awake_duration_milli: int
+    in_bed_duration_milli: Optional[int] = None
+    no_data_duration_milli: Optional[int] = None
+    sleep_cycle_count: Optional[int] = None
+    disturbance_count: Optional[int] = None
+
+    class Config:
+        from_attributes = True
+
+
+class SleepNeeded(BaseModel):
+    """Breakdown of sleep need (all values in milliseconds)."""
+
+    baseline_milli: Optional[int] = None
+    need_from_sleep_debt_milli: Optional[int] = None
+    need_from_recent_strain_milli: Optional[int] = None
+    need_from_recent_nap_milli: Optional[int] = None
 
     class Config:
         from_attributes = True
@@ -52,6 +68,7 @@ class SleepScore(BaseModel):
     sleep_performance_percentage: Optional[Decimal] = None
     sleep_consistency_percentage: Optional[Decimal] = None
     sleep_efficiency_percentage: Optional[Decimal] = None
+    sleep_needed: Optional[SleepNeeded] = None
 
     class Config:
         from_attributes = True
@@ -62,6 +79,8 @@ class SleepResponse(WhoopTimestampMixin, WhoopScoreMixin):
 
     id: UUID
     user_id: int
+    cycle_id: Optional[int] = None  # Whoop integer cycle id
+    v1_id: Optional[int] = None  # Legacy v1 sleep id (null for v2-native records)
     nap: bool
     sleep_stages: Optional[SleepStages] = None
     score: Optional[SleepScore] = None
@@ -104,7 +123,8 @@ class RecoveryResponse(WhoopScoreMixin):
 
     id: UUID
     user_id: int
-    cycle_id: UUID
+    cycle_id: Optional[int] = None  # Whoop integer cycle id
+    sleep_id: Optional[UUID] = None  # UUID of the sleep this recovery is derived from
     created_at: datetime
     score: Optional[RecoveryScore] = None
     calibrating: bool = False
@@ -214,6 +234,22 @@ class CycleCollection(BaseModel):
 
     records: List[CycleResponse]
     next_token: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ============================================================================
+# Body Measurement Models
+# ============================================================================
+
+
+class BodyMeasurementResponse(BaseModel):
+    """Body measurement record from Whoop API."""
+
+    height_meter: Optional[Decimal] = None
+    weight_kilogram: Optional[Decimal] = None
+    max_heart_rate: Optional[int] = None
 
     class Config:
         from_attributes = True

--- a/src/models/db_models.py
+++ b/src/models/db_models.py
@@ -8,6 +8,7 @@ import json
 from sqlalchemy import (
     Column,
     Integer,
+    BigInteger,
     String,
     DateTime,
     Boolean,
@@ -116,6 +117,9 @@ class User(Base):
     cycle_records = relationship(
         "CycleRecord", back_populates="user", cascade="all, delete-orphan"
     )
+    body_measurements = relationship(
+        "BodyMeasurement", back_populates="user", cascade="all, delete-orphan"
+    )
     sync_statuses = relationship(
         "SyncStatus", back_populates="user", cascade="all, delete-orphan"
     )
@@ -164,6 +168,10 @@ class SleepRecord(Base):
         index=True,
     )
 
+    # Linkage IDs (soft references, no FK constraint - related rows may sync later)
+    cycle_id = Column(BigInteger, index=True)  # Whoop integer cycle id this sleep belongs to
+    v1_id = Column(BigInteger)  # Legacy Whoop v1 sleep id (null for v2-native records)
+
     # Timestamps
     start_time = Column(DateTime(timezone=True), nullable=False, index=True)
     end_time = Column(DateTime(timezone=True), nullable=False, index=True)
@@ -174,6 +182,18 @@ class SleepRecord(Base):
     slow_wave_sleep_duration = Column(Integer)  # milliseconds
     rem_sleep_duration = Column(Integer)  # milliseconds
     awake_duration = Column(Integer)  # milliseconds
+    in_bed_duration = Column(Integer)  # milliseconds (total_in_bed_time_milli)
+    no_data_duration = Column(Integer)  # milliseconds (total_no_data_time_milli)
+
+    # Sleep architecture
+    sleep_cycle_count = Column(Integer)
+    disturbance_count = Column(Integer)
+
+    # Sleep need breakdown (in milliseconds)
+    sleep_needed_baseline = Column(Integer)  # baseline_milli
+    sleep_debt = Column(Integer)  # need_from_sleep_debt_milli
+    sleep_need_from_strain = Column(Integer)  # need_from_recent_strain_milli
+    sleep_need_from_nap = Column(Integer)  # need_from_recent_nap_milli
 
     # Metrics
     sleep_performance_percentage = Column(Numeric(5, 2))
@@ -214,7 +234,9 @@ class RecoveryRecord(Base):
         nullable=False,
         index=True,
     )
-    cycle_id = Column(UUID(as_uuid=True), index=True)  # Links to cycle if available
+    # Linkage IDs (soft references, no FK constraint - related rows may sync later)
+    cycle_id = Column(BigInteger, index=True)  # Whoop integer cycle id this recovery belongs to
+    sleep_id = Column(UUID(as_uuid=True), index=True)  # sleep_records.id this recovery is derived from
 
     # Timestamps
     created_at_whoop = Column(DateTime(timezone=True), nullable=False, index=True)
@@ -321,6 +343,10 @@ class CycleRecord(Base):
         index=True,
     )
 
+    # Natural Whoop integer cycle id (join target for sleep_records.cycle_id /
+    # recovery_records.cycle_id). Indexed soft key, not the primary key.
+    whoop_cycle_id = Column(BigInteger, index=True)
+
     # Timestamps
     start_time = Column(DateTime(timezone=True), nullable=False, index=True)
     end_time = Column(DateTime(timezone=True), nullable=False)
@@ -349,6 +375,48 @@ class CycleRecord(Base):
         return (
             f"<CycleRecord(id={self.id}, user_id={self.user_id}, "
             f"strain={self.strain_score})>"
+        )
+
+
+class BodyMeasurement(Base):
+    """Body measurement snapshots from Whoop API (height, weight, max HR).
+
+    The Whoop API only exposes the *current* measurement, so this is stored as
+    a time-series: a new row is written by the service only when a value differs
+    from the most recent stored row, building a change-history going forward.
+    """
+
+    __tablename__ = "body_measurements"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Measurements
+    height_meter = Column(Numeric(5, 3))  # e.g. 1.829
+    weight_kilogram = Column(Numeric(6, 3))  # e.g. 80.500
+    max_heart_rate = Column(Integer)  # beats per minute
+
+    # When this snapshot was captured (sync time)
+    recorded_at = Column(DateTime(timezone=True), nullable=False, index=True)
+
+    # Raw data
+    raw_data = Column(JSONType)
+
+    # Audit
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    user = relationship("User", back_populates="body_measurements")
+
+    def __repr__(self) -> str:
+        return (
+            f"<BodyMeasurement(id={self.id}, user_id={self.user_id}, "
+            f"weight_kilogram={self.weight_kilogram})>"
         )
 
 

--- a/src/services/body_measurement_service.py
+++ b/src/services/body_measurement_service.py
@@ -1,0 +1,270 @@
+"""Service for managing body measurement data from Whoop API.
+
+The Whoop API only returns the *current* body measurement (height, weight,
+max heart rate) with no history. This service stores it as a time-series:
+a new row is written only when a value differs from the most recent stored
+row, so weight/height changes accumulate going forward without daily duplicates.
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional, Dict, Any
+
+from sqlalchemy import select
+
+from src.api.whoop_client import WhoopClient, WhoopAPIError
+from src.models.db_models import BodyMeasurement, SyncStatus
+from src.database.session import get_db_context
+from src.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# HTTP statuses meaning "token can't read this" (e.g. read:body_measurement
+# scope not yet granted). Handled as a graceful skip rather than an error.
+_UNAUTHORIZED_STATUSES = (401, 403)
+
+
+def _to_decimal(value: Any, places: str = "0.001") -> Optional[Decimal]:
+    """Normalize an API numeric value to a fixed-precision Decimal.
+
+    Quantizing to the column's precision keeps change-detection stable (the
+    stored value and a freshly-fetched value compare equal when unchanged).
+    """
+    if value is None:
+        return None
+    return Decimal(str(value)).quantize(Decimal(places))
+
+
+class BodyMeasurementService:
+    """Service for managing body measurement data."""
+
+    def __init__(self, user_id: int, whoop_client: WhoopClient) -> None:
+        """
+        Initialize body measurement service.
+
+        Args:
+            user_id: Database user ID
+            whoop_client: Whoop API client instance
+        """
+        self.user_id = user_id
+        self.whoop_client = whoop_client
+
+        logger.info("Body measurement service initialized", user_id=user_id)
+
+    def _transform_api_record(self, api_record: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Transform Whoop API body measurement to database format.
+
+        Args:
+            api_record: Raw API response
+
+        Returns:
+            Dictionary matching BodyMeasurement model fields (excluding recorded_at)
+        """
+        return {
+            "user_id": self.user_id,
+            "height_meter": _to_decimal(api_record.get("height_meter")),
+            "weight_kilogram": _to_decimal(api_record.get("weight_kilogram")),
+            "max_heart_rate": api_record.get("max_heart_rate"),
+            "raw_data": api_record,
+        }
+
+    @staticmethod
+    def _is_changed(latest: Optional[BodyMeasurement], candidate: Dict[str, Any]) -> bool:
+        """Return True if candidate differs from the latest stored row (or none exists)."""
+        if latest is None:
+            return True
+        return (
+            latest.height_meter != candidate["height_meter"]
+            or latest.weight_kilogram != candidate["weight_kilogram"]
+            or latest.max_heart_rate != candidate["max_heart_rate"]
+        )
+
+    async def sync_body_measurement(self) -> int:
+        """
+        Sync the current body measurement from Whoop API.
+
+        Inserts a new time-series row only when a value has changed since the
+        last stored snapshot. If the token lacks the read:body_measurement
+        scope (401/403), the sync is skipped gracefully (not treated as an
+        error) so it auto-activates once the scope is granted.
+
+        Returns:
+            Number of records inserted (0 or 1)
+        """
+        logger.info("Starting body measurement sync", user_id=self.user_id)
+
+        try:
+            api_record = await self.whoop_client.get_body_measurement()
+        except WhoopAPIError as e:
+            if e.status_code in _UNAUTHORIZED_STATUSES:
+                logger.info(
+                    "Skipping body measurement sync; read:body_measurement scope "
+                    "not granted (re-authorize to enable)",
+                    user_id=self.user_id,
+                    status_code=e.status_code,
+                )
+                self._update_sync_status(
+                    status="skipped",
+                    records_fetched=0,
+                    last_sync_time=datetime.now(timezone.utc),
+                )
+                return 0
+            logger.error(
+                "Body measurement sync failed",
+                user_id=self.user_id,
+                status_code=e.status_code,
+                error=str(e),
+                exc_info=True,
+            )
+            self._update_sync_status(
+                status="error",
+                error_message=str(e),
+                last_sync_time=datetime.now(timezone.utc),
+            )
+            raise
+
+        candidate = self._transform_api_record(api_record)
+
+        try:
+            inserted = 0
+            now = datetime.now(timezone.utc)
+
+            with get_db_context() as db:
+                stmt = (
+                    select(BodyMeasurement)
+                    .where(BodyMeasurement.user_id == self.user_id)
+                    .order_by(BodyMeasurement.recorded_at.desc())
+                )
+                latest = db.execute(stmt).scalars().first()
+
+                if self._is_changed(latest, candidate):
+                    db.add(BodyMeasurement(recorded_at=now, **candidate))
+                    inserted = 1
+                    logger.info(
+                        "Inserted body measurement snapshot",
+                        user_id=self.user_id,
+                        weight_kilogram=str(candidate["weight_kilogram"]),
+                        max_heart_rate=candidate["max_heart_rate"],
+                    )
+                else:
+                    logger.info(
+                        "Body measurement unchanged; no new snapshot",
+                        user_id=self.user_id,
+                    )
+
+            self._update_sync_status(
+                status="success",
+                records_fetched=inserted,
+                last_sync_time=now,
+                last_record_time=now,
+            )
+
+            logger.info(
+                "Body measurement sync completed",
+                user_id=self.user_id,
+                records_synced=inserted,
+            )
+
+            return inserted
+
+        except Exception as e:
+            logger.error(
+                "Body measurement sync failed",
+                user_id=self.user_id,
+                error=str(e),
+                exc_info=True,
+            )
+            self._update_sync_status(
+                status="error",
+                error_message=str(e),
+                last_sync_time=datetime.now(timezone.utc),
+            )
+            raise
+
+    def _update_sync_status(
+        self,
+        status: str,
+        records_fetched: Optional[int] = None,
+        last_sync_time: Optional[datetime] = None,
+        last_record_time: Optional[datetime] = None,
+        error_message: Optional[str] = None,
+    ) -> None:
+        """Update sync status row for the body_measurement data type."""
+        with get_db_context() as db:
+            stmt = (
+                select(SyncStatus)
+                .where(SyncStatus.user_id == self.user_id)
+                .where(SyncStatus.data_type == "body_measurement")
+            )
+            sync_status = db.execute(stmt).scalar_one_or_none()
+
+            if sync_status:
+                sync_status.status = status
+                sync_status.last_sync_time = last_sync_time or datetime.now(timezone.utc)
+
+                if records_fetched is not None:
+                    sync_status.records_fetched = records_fetched
+                if last_record_time:
+                    sync_status.last_record_time = last_record_time
+                if error_message:
+                    sync_status.error_message = error_message
+                else:
+                    sync_status.error_message = None
+
+                sync_status.updated_at = datetime.now(timezone.utc)
+            else:
+                sync_status = SyncStatus(
+                    user_id=self.user_id,
+                    data_type="body_measurement",
+                    status=status,
+                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
+                    last_record_time=last_record_time,
+                    records_fetched=records_fetched,
+                    error_message=error_message,
+                )
+                db.add(sync_status)
+
+            logger.debug(
+                "Updated sync status",
+                data_type="body_measurement",
+                status=status,
+                records_fetched=records_fetched,
+            )
+
+    async def get_body_measurement_statistics(self) -> Dict[str, Any]:
+        """
+        Get body measurement statistics for user.
+
+        Returns:
+            Dictionary with snapshot count and the latest measurement.
+        """
+        with get_db_context() as db:
+            stmt = (
+                select(BodyMeasurement)
+                .where(BodyMeasurement.user_id == self.user_id)
+                .order_by(BodyMeasurement.recorded_at.desc())
+            )
+            records = db.execute(stmt).scalars().all()
+
+            if not records:
+                return {"total_records": 0, "latest": None}
+
+            latest = records[0]
+            return {
+                "total_records": len(records),
+                "latest": {
+                    "height_meter": (
+                        float(latest.height_meter)
+                        if latest.height_meter is not None
+                        else None
+                    ),
+                    "weight_kilogram": (
+                        float(latest.weight_kilogram)
+                        if latest.weight_kilogram is not None
+                        else None
+                    ),
+                    "max_heart_rate": latest.max_heart_rate,
+                    "recorded_at": latest.recorded_at.isoformat(),
+                },
+            }

--- a/src/services/body_measurement_service.py
+++ b/src/services/body_measurement_service.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from typing import Optional, Dict, Any
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 
 from src.api.whoop_client import WhoopClient, WhoopAPIError
 from src.models.db_models import BodyMeasurement, SyncStatus
@@ -139,7 +140,7 @@ class BodyMeasurementService:
                 latest = db.execute(stmt).scalars().first()
 
                 if self._is_changed(latest, candidate):
-                    db.add(BodyMeasurement(recorded_at=now, **candidate))
+                    db.execute(insert(BodyMeasurement).values(recorded_at=now, **candidate))
                     inserted = 1
                     logger.info(
                         "Inserted body measurement snapshot",

--- a/src/services/cycle_service.py
+++ b/src/services/cycle_service.py
@@ -65,11 +65,13 @@ class CycleService:
                 api_record["end"].replace("Z", "+00:00")
             )
 
-        # Note: v2 API provides integer id, but our DB uses auto-generated UUID
-        # We store the API integer id in raw_data for reference
+        # Note: v2 API provides an integer id, but our DB primary key is an
+        # auto-generated UUID. We persist the integer id as whoop_cycle_id so
+        # sleep/recovery records can join back to their cycle.
         return {
             # "id" omitted - let database auto-generate UUID (API provides integer)
             "user_id": self.user_id,
+            "whoop_cycle_id": api_record.get("id"),
             "start_time": datetime.fromisoformat(
                 api_record["start"].replace("Z", "+00:00")
             ),

--- a/src/services/data_collector.py
+++ b/src/services/data_collector.py
@@ -15,6 +15,7 @@ from src.services.sleep_service import SleepService
 from src.services.recovery_service import RecoveryService
 from src.services.workout_service import WorkoutService
 from src.services.cycle_service import CycleService
+from src.services.body_measurement_service import BodyMeasurementService
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -66,6 +67,9 @@ class DataCollector:
         self.recovery_service = RecoveryService(user_id, self.whoop_client)
         self.workout_service = WorkoutService(user_id, self.whoop_client)
         self.cycle_service = CycleService(user_id, self.whoop_client)
+        self.body_measurement_service = BodyMeasurementService(
+            user_id, self.whoop_client
+        )
 
         logger.info("Data collector initialized", user_id=user_id)
 
@@ -84,7 +88,8 @@ class DataCollector:
             start: Start date for records (uses last sync if None)
             end: End date for records
             data_types: List of data types to sync (all if None)
-                       Options: "sleep", "recovery", "workout", "cycle"
+                       Options: "sleep", "recovery", "workout", "cycle",
+                       "body_measurement"
 
         Returns:
             Dictionary with sync results for each data type
@@ -98,7 +103,7 @@ class DataCollector:
         )
 
         # Determine which data types to sync
-        all_data_types = ["sleep", "recovery", "workout", "cycle"]
+        all_data_types = ["sleep", "recovery", "workout", "cycle", "body_measurement"]
         data_types = data_types or all_data_types
 
         # Validate data types
@@ -137,6 +142,15 @@ class DataCollector:
             )
             tasks.append(task)
             sync_map[task] = "cycle"
+
+        if "body_measurement" in data_types:
+            # No start/end: the API only exposes the current measurement.
+            # The service skips gracefully if the scope isn't granted yet.
+            task = asyncio.create_task(
+                self.body_measurement_service.sync_body_measurement()
+            )
+            tasks.append(task)
+            sync_map[task] = "body_measurement"
 
         # Wait for all tasks to complete
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -262,6 +276,15 @@ class DataCollector:
         """
         return await self.cycle_service.sync_cycle_records(start=start, end=end)
 
+    async def sync_body_measurement(self) -> int:
+        """
+        Sync only body measurement data.
+
+        Returns:
+            Number of records inserted (0 or 1)
+        """
+        return await self.body_measurement_service.sync_body_measurement()
+
     async def get_all_statistics(self) -> Dict[str, Any]:
         """
         Get statistics for all data types.
@@ -272,11 +295,18 @@ class DataCollector:
         logger.info("Fetching statistics", user_id=self.user_id)
 
         # Fetch all statistics concurrently
-        sleep_stats, recovery_stats, workout_stats, cycle_stats = await asyncio.gather(
+        (
+            sleep_stats,
+            recovery_stats,
+            workout_stats,
+            cycle_stats,
+            body_measurement_stats,
+        ) = await asyncio.gather(
             self.sleep_service.get_sleep_statistics(),
             self.recovery_service.get_recovery_statistics(),
             self.workout_service.get_workout_statistics(),
             self.cycle_service.get_cycle_statistics(),
+            self.body_measurement_service.get_body_measurement_statistics(),
         )
 
         return {
@@ -285,6 +315,7 @@ class DataCollector:
             "recovery": recovery_stats,
             "workout": workout_stats,
             "cycle": cycle_stats,
+            "body_measurement": body_measurement_stats,
         }
 
     async def verify_token(self) -> bool:

--- a/src/services/recovery_service.py
+++ b/src/services/recovery_service.py
@@ -58,12 +58,15 @@ class RecoveryService:
         # Extract nested score data
         score = api_record.get("score", {})
 
-        # Note: v2 API doesn't provide a recovery ID - we use DB auto-generated UUID
-        # cycle_id in API is integer, but our DB uses UUID - we store API data in raw_data
+        # Note: v2 API doesn't provide a recovery ID - we use DB auto-generated UUID.
+        # cycle_id is the Whoop integer cycle id; sleep_id is the UUID of the sleep
+        # record this recovery is derived from (joins to sleep_records.id).
+        sleep_id = api_record.get("sleep_id")
         return {
             # "id" omitted - let database auto-generate UUID
             "user_id": self.user_id,
-            # "cycle_id" omitted - API provides integer, DB expects UUID (stored in raw_data)
+            "cycle_id": api_record.get("cycle_id"),
+            "sleep_id": UUID(sleep_id) if sleep_id else None,
             "created_at_whoop": datetime.fromisoformat(
                 api_record["created_at"].replace("Z", "+00:00")
             ),

--- a/src/services/sleep_service.py
+++ b/src/services/sleep_service.py
@@ -57,10 +57,14 @@ class SleepService:
         """
         # Extract nested score data
         score = api_record.get("score", {})
+        stage_summary = score.get("stage_summary", {})
+        sleep_needed = score.get("sleep_needed", {})
 
         return {
             "id": UUID(api_record["id"]),
             "user_id": self.user_id,
+            "cycle_id": api_record.get("cycle_id"),
+            "v1_id": api_record.get("v1_id"),
             "start_time": datetime.fromisoformat(
                 api_record["start"].replace("Z", "+00:00")
             ),
@@ -68,18 +72,20 @@ class SleepService:
                 api_record["end"].replace("Z", "+00:00")
             ),
             "timezone_offset": api_record.get("timezone_offset"),
-            "light_sleep_duration": score.get("stage_summary", {}).get(
-                "total_light_sleep_time_milli"
-            ),
-            "slow_wave_sleep_duration": score.get("stage_summary", {}).get(
+            "light_sleep_duration": stage_summary.get("total_light_sleep_time_milli"),
+            "slow_wave_sleep_duration": stage_summary.get(
                 "total_slow_wave_sleep_time_milli"
             ),
-            "rem_sleep_duration": score.get("stage_summary", {}).get(
-                "total_rem_sleep_time_milli"
-            ),
-            "awake_duration": score.get("stage_summary", {}).get(
-                "total_awake_time_milli"
-            ),
+            "rem_sleep_duration": stage_summary.get("total_rem_sleep_time_milli"),
+            "awake_duration": stage_summary.get("total_awake_time_milli"),
+            "in_bed_duration": stage_summary.get("total_in_bed_time_milli"),
+            "no_data_duration": stage_summary.get("total_no_data_time_milli"),
+            "sleep_cycle_count": stage_summary.get("sleep_cycle_count"),
+            "disturbance_count": stage_summary.get("disturbance_count"),
+            "sleep_needed_baseline": sleep_needed.get("baseline_milli"),
+            "sleep_debt": sleep_needed.get("need_from_sleep_debt_milli"),
+            "sleep_need_from_strain": sleep_needed.get("need_from_recent_strain_milli"),
+            "sleep_need_from_nap": sleep_needed.get("need_from_recent_nap_milli"),
             "sleep_performance_percentage": score.get("sleep_performance_percentage"),
             "sleep_consistency_percentage": score.get("sleep_consistency_percentage"),
             "respiratory_rate": score.get("respiratory_rate"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import StaticPool
 from faker import Faker
 
-from src.models.db_models import Base, User, OAuthToken, SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord
+from src.models.db_models import Base, User, OAuthToken, SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, BodyMeasurement
 from src.config import settings
 from src.auth.encryption import get_token_encryption
 
@@ -179,7 +179,8 @@ def test_recovery_record(db_session: Session, test_user: User) -> RecoveryRecord
     record = RecoveryRecord(
         id=uuid4(),
         user_id=test_user.id,
-        cycle_id=uuid4(),
+        cycle_id=1545424244,
+        sleep_id=uuid4(),
         created_at_whoop=datetime.now(timezone.utc),
         recovery_score=75.0,
         resting_heart_rate=55,
@@ -251,6 +252,23 @@ def test_cycle_record(db_session: Session, test_user: User) -> CycleRecord:
     return record
 
 
+@pytest.fixture
+def test_body_measurement(db_session: Session, test_user: User) -> BodyMeasurement:
+    """Create a test body measurement record."""
+    record = BodyMeasurement(
+        user_id=test_user.id,
+        height_meter=1.829,
+        weight_kilogram=90.718,
+        max_heart_rate=190,
+        recorded_at=datetime.now(timezone.utc),
+        raw_data={"test": "data"},
+    )
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return record
+
+
 # ============================================================================
 # API Mock Data
 # ============================================================================
@@ -262,6 +280,8 @@ def mock_whoop_sleep_response() -> dict:
         "records": [
             {
                 "id": str(uuid4()),
+                "cycle_id": 1545424244,
+                "v1_id": None,
                 "start": "2025-12-18T00:00:00.000Z",
                 "end": "2025-12-18T08:00:00.000Z",
                 "timezone_offset": "-05:00",
@@ -273,6 +293,16 @@ def mock_whoop_sleep_response() -> dict:
                         "total_slow_wave_sleep_time_milli": 120000,
                         "total_rem_sleep_time_milli": 60000,
                         "total_awake_time_milli": 30000,
+                        "total_in_bed_time_milli": 390000,
+                        "total_no_data_time_milli": 0,
+                        "sleep_cycle_count": 5,
+                        "disturbance_count": 8,
+                    },
+                    "sleep_needed": {
+                        "baseline_milli": 26785666,
+                        "need_from_sleep_debt_milli": 2869059,
+                        "need_from_recent_strain_milli": 165613,
+                        "need_from_recent_nap_milli": 0,
                     },
                     "sleep_performance_percentage": 85.5,
                     "sleep_consistency_percentage": 90.0,
@@ -292,7 +322,8 @@ def mock_whoop_recovery_response() -> dict:
         "records": [
             {
                 "id": str(uuid4()),
-                "cycle_id": str(uuid4()),
+                "cycle_id": 1545424244,
+                "sleep_id": str(uuid4()),
                 "created_at": "2025-12-18T08:00:00.000Z",
                 "score_state": "SCORED",
                 "score": {
@@ -351,7 +382,7 @@ def mock_whoop_cycle_response() -> dict:
     return {
         "records": [
             {
-                "id": str(uuid4()),
+                "id": 1545424244,
                 "start": "2025-12-17T00:00:00.000Z",
                 "end": "2025-12-18T00:00:00.000Z",
                 "timezone_offset": "-05:00",
@@ -365,6 +396,16 @@ def mock_whoop_cycle_response() -> dict:
             }
         ],
         "next_token": None,
+    }
+
+
+@pytest.fixture
+def mock_whoop_body_measurement() -> dict:
+    """Mock Whoop API body measurement response."""
+    return {
+        "height_meter": 1.8288,
+        "weight_kilogram": 90.7185,
+        "max_heart_rate": 190,
     }
 
 

--- a/tests/integration/test_data_sync.py
+++ b/tests/integration/test_data_sync.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, AsyncMock
 from src.services.data_collector import DataCollector
 from src.services.sleep_service import SleepService
 from src.api.whoop_client import WhoopClient
-from src.models.db_models import SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, SyncStatus
+from src.models.db_models import SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, BodyMeasurement, SyncStatus
 
 
 @pytest.mark.integration
@@ -141,6 +141,7 @@ class TestDataSyncIntegration:
         mock_whoop_recovery_response,
         mock_whoop_workout_response,
         mock_whoop_cycle_response,
+        mock_whoop_body_measurement,
     ):
         """Test syncing all data types through DataCollector."""
         collector = DataCollector(user_id=test_user.id)
@@ -164,31 +165,37 @@ class TestDataSyncIntegration:
                 respx.get(f"{collector.whoop_client.base_url}/developer/v2/cycle").mock(
                     return_value=httpx.Response(200, json=mock_whoop_cycle_response)
                 )
+                respx.get(f"{collector.whoop_client.base_url}/developer/v2/user/measurement/body").mock(
+                    return_value=httpx.Response(200, json=mock_whoop_body_measurement)
+                )
 
                 # Mock database contexts for all services
                 with patch("src.services.sleep_service.get_db_context") as mock_sleep:
                     with patch("src.services.recovery_service.get_db_context") as mock_recovery:
                         with patch("src.services.workout_service.get_db_context") as mock_workout:
-                            with patch("src.services.cycle_service.get_db_context") as mock_cycle:
-                                for mock_ctx in [mock_sleep, mock_recovery, mock_workout, mock_cycle]:
+                            with patch("src.services.cycle_service.get_db_context") as mock_cycle, \
+                                 patch("src.services.body_measurement_service.get_db_context") as mock_body:
+                                for mock_ctx in [mock_sleep, mock_recovery, mock_workout, mock_cycle, mock_body]:
                                     mock_ctx.return_value.__enter__.return_value = db_session
                                     mock_ctx.return_value.__exit__.return_value = None
 
                                 # Perform full sync
                                 results = await collector.sync_all_data()
 
-                                assert results["total_records"] == 4
+                                assert results["total_records"] == 5
                                 assert results["total_errors"] == 0
                                 assert results["results"]["sleep"]["status"] == "success"
                                 assert results["results"]["recovery"]["status"] == "success"
                                 assert results["results"]["workout"]["status"] == "success"
                                 assert results["results"]["cycle"]["status"] == "success"
+                                assert results["results"]["body_measurement"]["status"] == "success"
 
                                 # Verify all records in database
                                 assert db_session.query(SleepRecord).count() == 1
                                 assert db_session.query(RecoveryRecord).count() == 1
                                 assert db_session.query(WorkoutRecord).count() == 1
                                 assert db_session.query(CycleRecord).count() == 1
+                                assert db_session.query(BodyMeasurement).count() == 1
 
     @respx.mock
     async def test_incremental_sync(

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -175,10 +175,11 @@ class TestDatabaseIntegration:
 
     def test_recovery_with_cycle_reference(self, db_session, test_user):
         """Test recovery record with cycle reference."""
-        # Create cycle
+        # Create cycle (recovery links via the integer whoop_cycle_id, not the UUID pk)
         cycle = CycleRecord(
             id=uuid4(),
             user_id=test_user.id,
+            whoop_cycle_id=1545424244,
             start_time=datetime.now(timezone.utc) - timedelta(hours=24),
             end_time=datetime.now(timezone.utc),
         )
@@ -189,7 +190,7 @@ class TestDatabaseIntegration:
         recovery = RecoveryRecord(
             id=uuid4(),
             user_id=test_user.id,
-            cycle_id=cycle.id,
+            cycle_id=cycle.whoop_cycle_id,
             created_at_whoop=datetime.now(timezone.utc),
             recovery_score=75.0,
         )
@@ -198,7 +199,7 @@ class TestDatabaseIntegration:
 
         db_session.refresh(recovery)
 
-        assert recovery.cycle_id == cycle.id
+        assert recovery.cycle_id == cycle.whoop_cycle_id
 
     def test_jsonb_raw_data_storage(self, db_session, test_user):
         """Test storing raw JSON data."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from uuid import uuid4
 from sqlalchemy.exc import IntegrityError
 
-from src.models.db_models import User, OAuthToken, SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, SyncStatus
+from src.models.db_models import User, OAuthToken, SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, BodyMeasurement, SyncStatus
 
 
 @pytest.mark.unit
@@ -236,6 +236,28 @@ class TestCycleRecordModel:
         assert record.id is not None
         assert record.strain_score == 14.5
         assert record.kilojoules == 2000.0
+
+
+@pytest.mark.unit
+class TestBodyMeasurementModel:
+    """Tests for BodyMeasurement model."""
+
+    def test_create_body_measurement(self, db_session, test_user):
+        """Test creating a body measurement record."""
+        record = BodyMeasurement(
+            user_id=test_user.id,
+            height_meter=1.829,
+            weight_kilogram=90.718,
+            max_heart_rate=190,
+            recorded_at=datetime.now(timezone.utc),
+            raw_data={"test": "data"},
+        )
+        db_session.add(record)
+        db_session.commit()
+
+        assert record.id is not None
+        assert record.max_heart_rate == 190
+        assert float(record.weight_kilogram) == 90.718
 
 
 @pytest.mark.unit

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -9,9 +9,10 @@ from src.services.sleep_service import SleepService
 from src.services.recovery_service import RecoveryService
 from src.services.workout_service import WorkoutService
 from src.services.cycle_service import CycleService
+from src.services.body_measurement_service import BodyMeasurementService
 from src.services.data_collector import DataCollector, sync_user_data
-from src.api.whoop_client import WhoopClient
-from src.models.db_models import SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, SyncStatus
+from src.api.whoop_client import WhoopClient, WhoopAPIError
+from src.models.db_models import SleepRecord, RecoveryRecord, WorkoutRecord, CycleRecord, BodyMeasurement, SyncStatus
 
 
 @pytest.mark.unit
@@ -41,6 +42,17 @@ class TestSleepService:
         assert "end_time" in db_record
         assert db_record["sleep_performance_percentage"] == 85.5
         assert db_record["raw_data"] == api_record
+        # Promoted fields and linkage
+        assert db_record["cycle_id"] == 1545424244
+        assert db_record["v1_id"] is None
+        assert db_record["in_bed_duration"] == 390000
+        assert db_record["no_data_duration"] == 0
+        assert db_record["sleep_cycle_count"] == 5
+        assert db_record["disturbance_count"] == 8
+        assert db_record["sleep_needed_baseline"] == 26785666
+        assert db_record["sleep_debt"] == 2869059
+        assert db_record["sleep_need_from_strain"] == 165613
+        assert db_record["sleep_need_from_nap"] == 0
 
     async def test_sync_sleep_records(self, test_user, db_session, mock_whoop_sleep_response):
         """Test syncing sleep records."""
@@ -116,6 +128,9 @@ class TestRecoveryService:
         assert db_record["user_id"] == test_user.id
         assert db_record["recovery_score"] == 75.0
         assert db_record["hrv_rmssd"] == 65.5
+        # Linkage: integer cycle_id and the sleep UUID this recovery derives from
+        assert db_record["cycle_id"] == 1545424244
+        assert str(db_record["sleep_id"]) == api_record["sleep_id"]
 
 
 @pytest.mark.unit
@@ -167,6 +182,124 @@ class TestCycleService:
         assert db_record["user_id"] == test_user.id
         assert db_record["strain_score"] == 14.5
         assert db_record["kilojoules"] == 2000.0
+        assert db_record["whoop_cycle_id"] == 1545424244
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestBodyMeasurementService:
+    """Tests for BodyMeasurementService."""
+
+    async def test_transform_api_record(self, test_user, mock_whoop_body_measurement):
+        """Test transforming and normalizing a body measurement record."""
+        client = WhoopClient(user_id=test_user.id)
+        service = BodyMeasurementService(user_id=test_user.id, whoop_client=client)
+
+        db_record = service._transform_api_record(mock_whoop_body_measurement)
+
+        assert db_record["user_id"] == test_user.id
+        assert db_record["max_heart_rate"] == 190
+        # Values are quantized to the column precision (3 decimals)
+        assert str(db_record["height_meter"]) == "1.829"
+        assert str(db_record["weight_kilogram"]) == "90.718"
+        assert db_record["raw_data"] == mock_whoop_body_measurement
+
+    async def test_sync_inserts_when_changed(
+        self, test_user, db_session, mock_whoop_body_measurement
+    ):
+        """A new measurement is inserted when none exists yet."""
+        client = WhoopClient(user_id=test_user.id)
+        service = BodyMeasurementService(user_id=test_user.id, whoop_client=client)
+
+        def mock_exit(*args):
+            db_session.commit()
+            return None
+
+        with patch.object(
+            client,
+            "get_body_measurement",
+            new=AsyncMock(return_value=mock_whoop_body_measurement),
+        ):
+            with patch(
+                "src.services.body_measurement_service.get_db_context"
+            ) as mock_context:
+                mock_context.return_value.__enter__.return_value = db_session
+                mock_context.return_value.__exit__ = mock_exit
+
+                inserted = await service.sync_body_measurement()
+
+                assert inserted == 1
+                rows = (
+                    db_session.query(BodyMeasurement)
+                    .filter_by(user_id=test_user.id)
+                    .all()
+                )
+                assert len(rows) == 1
+                assert rows[0].max_heart_rate == 190
+
+    async def test_sync_skips_when_unchanged(
+        self, test_user, db_session, test_body_measurement, mock_whoop_body_measurement
+    ):
+        """No new row when the fetched values match the latest stored snapshot."""
+        client = WhoopClient(user_id=test_user.id)
+        service = BodyMeasurementService(user_id=test_user.id, whoop_client=client)
+
+        def mock_exit(*args):
+            db_session.commit()
+            return None
+
+        with patch.object(
+            client,
+            "get_body_measurement",
+            new=AsyncMock(return_value=mock_whoop_body_measurement),
+        ):
+            with patch(
+                "src.services.body_measurement_service.get_db_context"
+            ) as mock_context:
+                mock_context.return_value.__enter__.return_value = db_session
+                mock_context.return_value.__exit__ = mock_exit
+
+                inserted = await service.sync_body_measurement()
+
+                assert inserted == 0
+                # Still just the one pre-existing row
+                rows = (
+                    db_session.query(BodyMeasurement)
+                    .filter_by(user_id=test_user.id)
+                    .all()
+                )
+                assert len(rows) == 1
+
+    async def test_sync_skips_gracefully_without_scope(self, test_user, db_session):
+        """A 403 (scope not granted) is a graceful skip, not an error."""
+        client = WhoopClient(user_id=test_user.id)
+        service = BodyMeasurementService(user_id=test_user.id, whoop_client=client)
+
+        def mock_exit(*args):
+            db_session.commit()
+            return None
+
+        with patch.object(
+            client,
+            "get_body_measurement",
+            new=AsyncMock(side_effect=WhoopAPIError("forbidden", status_code=403)),
+        ):
+            with patch(
+                "src.services.body_measurement_service.get_db_context"
+            ) as mock_context:
+                mock_context.return_value.__enter__.return_value = db_session
+                mock_context.return_value.__exit__ = mock_exit
+
+                inserted = await service.sync_body_measurement()
+
+                assert inserted == 0
+                sync_status = (
+                    db_session.query(SyncStatus)
+                    .filter_by(user_id=test_user.id, data_type="body_measurement")
+                    .first()
+                )
+                assert sync_status is not None
+                assert sync_status.status == "skipped"
 
 
 @pytest.mark.unit
@@ -209,16 +342,21 @@ class TestDataCollector:
                         collector.cycle_service,
                         "sync_cycle_records",
                         new=AsyncMock(return_value=5),
+                    ), patch.object(
+                        collector.body_measurement_service,
+                        "sync_body_measurement",
+                        new=AsyncMock(return_value=1),
                     ):
                         results = await collector.sync_all_data()
 
                         assert results["user_id"] == test_user.id
-                        assert results["total_records"] == 18
+                        assert results["total_records"] == 19
                         assert results["total_errors"] == 0
                         assert results["results"]["sleep"]["records_synced"] == 5
                         assert results["results"]["recovery"]["records_synced"] == 5
                         assert results["results"]["workout"]["records_synced"] == 3
                         assert results["results"]["cycle"]["records_synced"] == 5
+                        assert results["results"]["body_measurement"]["records_synced"] == 1
 
     async def test_sync_all_data_with_errors(self, test_user):
         """Test syncing with some errors."""
@@ -244,6 +382,10 @@ class TestDataCollector:
                         collector.cycle_service,
                         "sync_cycle_records",
                         new=AsyncMock(return_value=5),
+                    ), patch.object(
+                        collector.body_measurement_service,
+                        "sync_body_measurement",
+                        new=AsyncMock(return_value=0),
                     ):
                         results = await collector.sync_all_data()
 
@@ -310,6 +452,10 @@ class TestDataCollector:
                         collector.cycle_service,
                         "get_cycle_statistics",
                         new=AsyncMock(return_value=mock_stats),
+                    ), patch.object(
+                        collector.body_measurement_service,
+                        "get_body_measurement_statistics",
+                        new=AsyncMock(return_value=mock_stats),
                     ):
                         stats = await collector.get_all_statistics()
 
@@ -318,6 +464,7 @@ class TestDataCollector:
                         assert stats["recovery"]["total_records"] == 10
                         assert stats["workout"]["total_records"] == 10
                         assert stats["cycle"]["total_records"] == 10
+                        assert stats["body_measurement"]["total_records"] == 10
 
     async def test_verify_token(self, test_user):
         """Test verifying token."""


### PR DESCRIPTION
## Summary

Expands what Whoopster captures from the Whoop API v2, in two parts.

### 1. Sleep debt, disturbances & cycle↔sleep↔recovery linkage (no re-auth)
All of these were already arriving in the `raw_data` JSONB — this promotes them to first-class, queryable columns and backfills existing rows in the migration.

- **`sleep_records`**: sleep-need breakdown (`baseline`/`debt`/`strain`/`nap`), `disturbance_count`, `sleep_cycle_count`, in-bed / no-data durations, `cycle_id`, `v1_id`
- **`recovery_records`**: add `sleep_id`; **fix `cycle_id` type `UUID` → `BIGINT`** (the old UUID column could never hold Whoop's integer cycle id, so it sat unused)
- **`cycle_records`**: add `whoop_cycle_id` (the integer join key)
- Together these enable native **cycle ↔ sleep ↔ recovery** joins

> Note on disturbances: Whoop only exposes an aggregate `disturbance_count` per night — there are no per-disturbance timestamps in the API, so nightly count is the finest granularity available.

### 2. Body measurements (requires `read:body_measurement` scope)
- New **`body_measurements`** table (`height_meter`, `weight_kilogram`, `max_heart_rate`) stored as an **insert-on-change time series** (the API only returns the current value, so history accrues going forward without daily duplicates)
- `get_body_measurement()` client method + `BodyMeasurementService`
- Wired into `DataCollector`; **skips gracefully (not an error) on 401/403** until the scope is granted, then **auto-activates** once a re-authed token lands

### Supporting changes
- Add `read:body_measurement` to requested OAuth scopes
- Wire `TOKEN_ENCRYPTION_KEY` into `docker-compose.yml` (it was missing from the app service's env)
- Add standalone `docker-compose.app.yml` (app-only, all config from `.env`) for running/re-authing against an external DB

## Migrations
Two migrations chain off the current head and **run automatically at startup** (`entrypoint.py` → `alembic upgrade head`):
- `a1b2c3d4e5f6` — sleep/linkage columns + type fix + raw_data backfill
- `b2c3d4e5f6a7` — `body_measurements` table

## Testing
- Full unit suite green: **119 passing**
- New tests cover the body-measurement transform, insert-on-change, the 401/403 graceful-skip path, and the new model/columns
- JSONB backfill expressions validated against production data before being written into the migration

## Deploy notes
- The `read:body_measurement` token re-auth has already been performed (user 1), so body-measurement sync activates on the first cycle after deploy.