### PR TITLE
Close deletion/rescore gaps with a windowed reconciliation poll (defer webhooks)

### DIFF
--- a/docs/WEBHOOKS_PLAN.md
+++ b/docs/WEBHOOKS_PLAN.md
@@ -1,0 +1,243 @@
+# Whoop Webhooks — Implementation Plan
+
+> ## ⛔ DEFERRED — not being implemented
+>
+> Webhooks are **completely deferred**. The two data-correctness gaps that
+> motivated them (§1: silent deletions and missed late rescores) are now closed
+> by a **windowed reconciliation poll** instead — no inbound endpoint, no
+> FastAPI/uvicorn receiver, and no Cloudflare WAF cost. See
+> `src/services/reconcile.py` and the recovery/cycle upsert + dedup migration.
+>
+> The rest of this document is **retained for reference only**, in case real-time
+> webhooks are ever revisited (e.g. to relax the poll cadence). If picked back up,
+> it should be built on Cloudflare's free tier (in-app method/path + rate limiting,
+> free edge DDoS), not the $20/mo Pro plan.
+>
+> _Original status: proposed / under review (receiver in-process with the
+> scheduler; 15-minute poll kept as a reconciliation backup)._
+
+## 1. Why we're doing this (the actual motivation)
+
+Timeliness is **not** the driver — 15-minute polling is fresh enough. The real
+gaps are data-correctness problems that polling cannot structurally fix:
+
+1. **Deletions are silently dropped, permanently.** Every service uses
+   `INSERT ... ON CONFLICT DO UPDATE` (e.g. `src/services/sleep_service.py:168`).
+   There is no code path that ever deletes a row. If a record is deleted in the
+   Whoop app (mis-detected nap, rescore, bad record), the stale row lives in
+   Postgres forever. Polling list endpoints can't observe "this used to exist."
+   Only the `*.deleted` webhook events surface this.
+
+2. **Late rescoring of older records can be missed.** Incremental sync sets the
+   watermark to `last_record_time = max(record.end)`
+   (`src/services/sleep_service.py:190-198`) and queries `start = last_record_time`
+   next time. Whoop's `start`/`end` params filter on the record's *time range*,
+   not its *updated* time. Once the watermark passes a record's end, a later
+   rescore of that same record (`PENDING_SCORE → SCORED`, recovery finalizing
+   hours later, a manually edited sleep) won't be re-fetched. `*.updated` events
+   catch exactly this.
+
+3. **~96 polls/day that mostly return nothing** — minor here, but webhooks
+   remove the wasted API calls and rate-limit pressure.
+
+## 2. The constraint that shapes everything: webhooks are partial
+
+Whoop only emits webhooks for **sleep, recovery, and workout**. The docs
+explicitly state there are **no webhooks for Day Strain, cycles, or body
+measurements**. We sync all five (`src/services/data_collector.py:106`).
+
+Therefore this is **hybrid, not a replacement**:
+
+- **Webhooks** drive sleep / recovery / workout (including deletes).
+- **Polling stays** for cycles + body measurements (no other option).
+- **Polling also stays as a backup** for the webhook-covered types — Whoop's own
+  docs warn webhooks can be missed and recommend "a reconciliation job that can
+  occasionally reach out to the WHOOP API." Per decision, we keep the existing
+  15-minute cadence as that safety net (can be relaxed later).
+
+## 3. Whoop webhook spec (reference)
+
+Source: <https://developer.whoop.com/docs/developing/webhooks/>
+
+**Event types (6):**
+`recovery.updated`, `recovery.deleted`, `workout.updated`, `workout.deleted`,
+`sleep.updated`, `sleep.deleted`.
+
+**Payload (POST body):**
+```json
+{
+  "user_id": 10129,
+  "id": 10235,
+  "type": "workout.updated",
+  "trace_id": "d3709ee7-104e-4f70-a928-2932964b017b"
+}
+```
+- `user_id` (int64) — the **Whoop** user id (not our internal `users.id`).
+- `id` — resource id; **v2 = UUID** (v1 = integer). We use v2 endpoints.
+- `type` — one of the 6 enums above.
+- `trace_id` — use for deduplication; duplicate deliveries are possible.
+
+**Signature headers:**
+- `X-WHOOP-Signature` — base64 signature value.
+- `X-WHOOP-Signature-Timestamp` — milliseconds since epoch.
+
+**Verification:**
+```
+calculated = base64( HMAC_SHA256( timestamp_header + raw_request_body, client_secret ) )
+```
+Compare `calculated` to `X-WHOOP-Signature` (constant-time). The client secret is
+the Whoop app's secret (we already hold it as `WHOOP_CLIENT_SECRET`).
+
+**Response/retry:**
+- Must return a `2XX` **within ~1 second**. Anything else (or a timeout) counts
+  as failure.
+- Whoop retries failed deliveries **5 times over ~1 hour**.
+- Webhooks are notifications only — the body carries no data; we must call the
+  API by `id` to fetch the actual record.
+- Deliveries may be missed entirely → reconciliation poll is mandatory.
+
+## 4. Application changes
+
+### 4.1 Dependencies (`pyproject.toml`)
+- `fastapi`, `uvicorn[standard]` — pinned `==` per project convention.
+
+### 4.2 Config (`src/config.py`)
+- `webhook_enabled: bool = False` — ships **dark**; flip on after Cloudflare + Whoop registration.
+- `webhook_port: int = 8080`
+- `webhook_path: str = "/webhooks/whoop"`
+- `webhook_signature_max_age_seconds: int = 300` — replay window.
+- Reuse existing `whoop_client_secret` for HMAC.
+
+### 4.3 New package `src/webhooks/`
+- **`signature.py`** — `verify(timestamp_header, raw_body, signature_header) -> bool`:
+  compute `base64(HMAC_SHA256(timestamp + raw_body, client_secret))`,
+  constant-time compare, reject stale timestamps (> max age).
+- **`app.py`** — FastAPI app with one `POST {webhook_path}` route plus `GET /healthz`:
+  1. Read the **raw** body bytes (hash the exact bytes — before JSON parsing).
+  2. Verify signature → `401` on failure.
+  3. Parse `{user_id, id, type, trace_id}`.
+  4. Dedup on `trace_id` (see 4.6).
+  5. **Enqueue** onto an in-process `asyncio.Queue`, return `200` immediately
+     (stays well under Whoop's ~1s timeout).
+- **`worker.py`** — async consumer draining the queue:
+  - `*.updated` → fetch the single resource by id → existing transform + upsert.
+  - `*.deleted` → delete the row. **Open decision:** hard delete (mirror Whoop)
+    vs. soft delete with a `deleted_at` tombstone for our own history.
+  - Resolve Whoop `user_id` → internal `users.id`.
+
+### 4.4 Whoop client (`src/api/whoop_client.py`)
+Add single-resource fetchers (reuse `_make_request`):
+- `get_sleep_by_id(id)`     → `GET /developer/v2/activity/sleep/{id}`
+- `get_workout_by_id(id)`   → `GET /developer/v2/activity/workout/{id}`
+- `get_recovery_by_id(id)`  → `GET /developer/v2/recovery/{id}` *(confirm exact path)*
+
+### 4.5 Lifecycle wiring (`src/main.py`)
+- In `startup()`, when `webhook_enabled`, launch uvicorn as an asyncio task on the
+  same loop as APScheduler; cancel it in `shutdown()`. The scheduler is unchanged
+  (15-min poll = backup + the only path for cycles/body measurement).
+
+### 4.6 Migration (Alembic)
+- New `webhook_events` table for `trace_id` dedup + audit:
+  `trace_id` (PK/unique), `event_type`, `whoop_user_id`, `resource_id`,
+  `received_at`, `processed_at`, `status`. DB-backed dedup survives restarts
+  (preferred over in-memory).
+
+### 4.7 Mapping prerequisite
+- The receiver needs `users.whoop_user_id` populated to resolve the internal id.
+  Confirm the column exists/is populated; add a one-time backfill if not.
+
+### 4.8 Tests (`tests/`)
+- Signature: valid / tampered body / stale timestamp / wrong secret.
+- Routing: `updated` → fetch + upsert; `deleted` → row removed; unknown user;
+  duplicate `trace_id` ignored.
+- Returns `200` before processing (enqueue, not inline).
+
+## 5. Cloudflare design — **review this carefully**
+
+### 5.1 The critical gotcha
+Our existing `cloudflared` runs **Zero Trust Access** (auth in front of services).
+We **cannot** put the webhook behind an Access policy: Whoop is an unauthenticated
+third party and would be bounced to a login page, so every delivery would fail.
+
+The webhook hostname must be **publicly reachable with no Access policy**, and
+protected by other layers instead.
+
+### 5.2 Topology
+```
+Whoop  ──HTTPS POST──▶  Cloudflare edge (WAF + rate limit + DDoS)
+                              │
+                              ▼
+                     cloudflared tunnel (existing container)
+                              │  public hostname, NO Access policy
+                              ▼
+                     app container :8080  /webhooks/whoop
+                              │
+                              ▼
+                     HMAC verify → enqueue → 200
+```
+
+### 5.3 Tunnel config — add a public hostname
+Add an ingress rule to the existing tunnel (example `config.yml`; adapt to however
+your cloudflared is currently configured — dashboard-managed tunnels do the
+equivalent under Public Hostnames):
+
+```yaml
+ingress:
+  # NEW: Whoop webhook receiver — public, NOT behind Access
+  - hostname: whoop-hooks.example.com
+    service: http://app:8080
+    # no "access" / no Zero Trust application bound to this hostname
+
+  # ... existing Zero-Trust-protected hostnames stay as they are ...
+
+  - service: http_status:404
+```
+
+> If the tunnel is **dashboard-managed**: add a Public Hostname
+> `whoop-hooks.example.com → http://app:8080` and make sure **no Access
+> application** is configured to match that hostname/path.
+
+### 5.4 WAF / security layers (the real protection)
+Because there's no Access gate, security comes from:
+
+1. **HMAC signature verification in-app** — the actual authentication. Only Whoop
+   knows our client secret. This is non-negotiable and is the primary control.
+2. **WAF custom rule** — only allow the exact method + path, block the rest, e.g.:
+   ```
+   (http.host eq "whoop-hooks.example.com"
+     and not (http.request.method eq "POST"
+              and http.request.uri.path eq "/webhooks/whoop"))
+   ```
+   → action: **Block**.
+3. **Rate limiting rule** on the hostname (e.g. N requests / 10s per IP) — Whoop's
+   real volume is tiny, so a low ceiling is safe.
+4. **Managed DDoS protection** — automatic at the Cloudflare edge.
+5. Whoop publishes **no source-IP allowlist**, so do **not** rely on IP filtering.
+6. Keep the path non-obvious if desired; return generic responses (no detail leak).
+
+### 5.5 Register with Whoop
+In the Whoop Developer Dashboard → app settings → **Webhooks**:
+- URL: `https://whoop-hooks.example.com/webhooks/whoop`
+- **Model Version: v2** (our client uses the v2 UUID endpoints).
+
+## 6. Docker / deploy
+- `docker-compose.yml`: the `app` service exposes `8080` **on the Docker network
+  only** (cloudflared reaches it as `http://app:8080`; no host port publish needed).
+- Add a webhook healthcheck (`GET /healthz`).
+- Ansible / secrets deploy mirrors the new env vars (`WEBHOOK_ENABLED`, etc.).
+
+## 7. Rollout order
+1. Ship code behind `webhook_enabled=false`; deploy.
+2. Add the Cloudflare public hostname + WAF + rate-limit rules.
+3. Register the URL in the Whoop Developer Dashboard (v2).
+4. Flip `webhook_enabled=true`; watch logs.
+5. Verify end-to-end: edit/delete a sleep in the Whoop app → confirm it
+   propagates (update applied / row removed).
+6. (Later, optional) relax the poll cadence from 15 min toward hourly/daily once
+   confident in webhook reliability.
+
+## 8. Open decisions
+- **Hard vs soft delete** on `*.deleted` events.
+- Confirm `read:*` scopes already cover the by-id endpoints (should match the
+  list-endpoint scopes).
+- Final public hostname name (`whoop-hooks.<domain>`).

--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,13 @@ class Settings(BaseSettings):
     sync_interval_minutes: int = 15
     environment: str = "development"
 
+    # Reconciliation: each poll re-fetches a trailing window and reconciles it
+    # against the DB, so late rescores and Whoop-side deletions are caught without
+    # webhooks. settle_minutes shields very recent rows from deletion while they
+    # are still settling / paginating in.
+    reconcile_window_days: int = 7
+    reconcile_settle_minutes: int = 60
+
     # Rate Limiting
     max_requests_per_minute: int = 60
 

--- a/src/database/migrations/versions/20260605_0900_c3d4e5f6a7b8_dedup_recovery_cycle_unique_keys.py
+++ b/src/database/migrations/versions/20260605_0900_c3d4e5f6a7b8_dedup_recovery_cycle_unique_keys.py
@@ -1,0 +1,70 @@
+"""Deduplicate recovery/cycle rows and add natural-key unique constraints
+
+recovery_records and cycle_records were inserted without an upsert (the comments
+claimed "no natural unique ID from API, so we can't upsert"). Because the list
+endpoints' `start` filter is inclusive, the boundary record was re-fetched and
+re-inserted on every poll, so duplicates accumulated (recovery especially: most
+rows were duplicates, which also inflated the row-count statistics).
+
+Both types do have a natural key in the data:
+- recovery: (user_id, cycle_id)        -- recovery is 1:1 with a Whoop cycle
+- cycle:    (user_id, whoop_cycle_id)  -- the Whoop integer cycle id
+
+This migration removes existing duplicates (keeping the most recently created row
+per key) and adds the unique constraints that let the services upsert instead of
+insert. The data operations use Postgres-only SQL (DELETE ... USING, ctid); the
+SQLite test schema is built from the models via create_all, not this file.
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-05 09:00:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'c3d4e5f6a7b8'
+down_revision = 'b2c3d4e5f6a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Remove duplicate rows, then add natural-key unique constraints."""
+    # --- Dedup recovery_records: keep the newest row per (user_id, cycle_id) ---
+    op.execute(
+        """
+        DELETE FROM recovery_records a
+        USING recovery_records b
+        WHERE a.user_id = b.user_id
+          AND a.cycle_id = b.cycle_id
+          AND a.cycle_id IS NOT NULL
+          AND (a.created_at, a.ctid) < (b.created_at, b.ctid)
+        """
+    )
+
+    # --- Dedup cycle_records: keep the newest row per (user_id, whoop_cycle_id) ---
+    op.execute(
+        """
+        DELETE FROM cycle_records a
+        USING cycle_records b
+        WHERE a.user_id = b.user_id
+          AND a.whoop_cycle_id = b.whoop_cycle_id
+          AND a.whoop_cycle_id IS NOT NULL
+          AND (a.created_at, a.ctid) < (b.created_at, b.ctid)
+        """
+    )
+
+    # --- Natural-key unique constraints (enable idempotent upsert) ---
+    op.create_unique_constraint(
+        'uq_recovery_user_cycle', 'recovery_records', ['user_id', 'cycle_id']
+    )
+    op.create_unique_constraint(
+        'uq_cycle_user_whoop_cycle', 'cycle_records', ['user_id', 'whoop_cycle_id']
+    )
+
+
+def downgrade() -> None:
+    """Drop the unique constraints (duplicate rows are not restored)."""
+    op.drop_constraint('uq_cycle_user_whoop_cycle', 'cycle_records', type_='unique')
+    op.drop_constraint('uq_recovery_user_cycle', 'recovery_records', type_='unique')

--- a/src/models/db_models.py
+++ b/src/models/db_models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     ARRAY,
     ForeignKey,
     TypeDecorator,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.declarative import declarative_base
@@ -268,6 +269,12 @@ class RecoveryRecord(Base):
             f"recovery_score={self.recovery_score})>"
         )
 
+    # One recovery per (user, Whoop cycle): the natural key the API exposes.
+    # Enables idempotent upsert and reconciliation (the API gives no recovery id).
+    __table_args__ = (
+        UniqueConstraint("user_id", "cycle_id", name="uq_recovery_user_cycle"),
+    )
+
 
 class WorkoutRecord(Base):
     """Workout data records from Whoop API."""
@@ -376,6 +383,14 @@ class CycleRecord(Base):
             f"<CycleRecord(id={self.id}, user_id={self.user_id}, "
             f"strain={self.strain_score})>"
         )
+
+    # One row per (user, Whoop cycle id): the natural key the API exposes.
+    # Enables idempotent upsert and reconciliation (DB id is an auto UUID).
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "whoop_cycle_id", name="uq_cycle_user_whoop_cycle"
+        ),
+    )
 
 
 class BodyMeasurement(Base):

--- a/src/services/cycle_service.py
+++ b/src/services/cycle_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import CycleRecord, SyncStatus
 from src.database.session import get_db_context
+from src.services.reconcile import windowed_start, reconcile_deletes
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -122,10 +123,12 @@ class CycleService:
                 sync_status = db.execute(stmt).scalar_one_or_none()
 
                 if sync_status and sync_status.last_record_time:
-                    start = sync_status.last_record_time
+                    # Re-fetch a trailing overlap window so late rescores upsert.
+                    start = windowed_start(sync_status.last_record_time)
                     logger.info(
-                        "Using last sync time as start",
+                        "Using last sync time as start (overlap window applied)",
                         start=start.isoformat(),
+                        watermark=sync_status.last_record_time.isoformat(),
                     )
 
         try:
@@ -162,9 +165,18 @@ class CycleService:
                         # Transform API record to database format
                         db_record = self._transform_api_record(api_record)
 
-                        # Insert record (no natural unique ID from API, so we can't upsert)
-                        # Database will auto-generate UUID for id field
+                        # Upsert on the natural key (user_id, whoop_cycle_id).
+                        # The DB id is an auto-generated UUID, but the Whoop integer
+                        # cycle id is unique per user, so re-fetched/rescored cycles
+                        # update in place instead of inserting duplicates.
                         stmt = insert(CycleRecord).values(**db_record)
+                        stmt = stmt.on_conflict_do_update(
+                            index_elements=["user_id", "whoop_cycle_id"],
+                            set_={
+                                **db_record,
+                                "updated_at": datetime.now(timezone.utc),
+                            },
+                        )
 
                         db.execute(stmt)
                         records_synced += 1
@@ -177,6 +189,21 @@ class CycleService:
                             exc_info=True,
                         )
                         # Continue with other records
+
+                # Reconcile deletions: drop completed cycles in the window the API
+                # no longer returns. Keyed on whoop_cycle_id (DB id is an auto UUID).
+                # Ongoing cycles have no end_time and are excluded by the window.
+                present_keys = {
+                    r.get("id") for r in api_records if r.get("id") is not None
+                }
+                reconcile_deletes(
+                    db,
+                    CycleRecord,
+                    user_id=self.user_id,
+                    time_column=CycleRecord.end_time,
+                    key_column=CycleRecord.whoop_cycle_id,
+                    present_keys=present_keys,
+                )
 
                 # Get most recent record time for next sync (from completed cycles only)
                 completed_records = [r for r in api_records if r.get("end")]

--- a/src/services/reconcile.py
+++ b/src/services/reconcile.py
@@ -1,0 +1,129 @@
+"""Shared helpers for windowed reconciliation of polled Whoop data.
+
+Polling alone can't observe two things, because every service upserts and never
+deletes, and advances a watermark past records once seen:
+
+* **Deletions** made in the Whoop app leave a stale row in our DB forever.
+* **Late rescores** of a record older than the watermark are never re-fetched.
+
+Both are fixed by re-fetching a trailing window on each poll and reconciling it
+against the database:
+
+* :func:`windowed_start` shifts the watermark back by the overlap window so the
+  list fetch re-includes recently-changed records (they then upsert in place).
+* :func:`reconcile_deletes` drops local rows inside the window that the API no
+  longer returns.
+
+The window/margin come from settings (``reconcile_window_days``,
+``reconcile_settle_minutes``).
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional, Set
+
+from sqlalchemy import select, delete as sa_delete
+from sqlalchemy.orm import InstrumentedAttribute, Session
+
+from src.config import settings
+from src.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def windowed_start(
+    last_record_time: Optional[datetime],
+    window_days: Optional[int] = None,
+) -> Optional[datetime]:
+    """Shift a sync watermark back by the overlap window.
+
+    Re-fetching the trailing window lets rescored/late-finalized records upsert
+    in place. ``None`` is returned unchanged so a first-ever sync still does a
+    full backfill rather than an empty window.
+
+    Args:
+        last_record_time: The stored watermark (max record time), or None.
+        window_days: Override the configured window (mainly for tests).
+
+    Returns:
+        The watermark minus the window, or None if no watermark exists.
+    """
+    if last_record_time is None:
+        return None
+    days = settings.reconcile_window_days if window_days is None else window_days
+    return last_record_time - timedelta(days=days)
+
+
+def reconcile_deletes(
+    db: Session,
+    model: Any,
+    *,
+    user_id: int,
+    time_column: InstrumentedAttribute,
+    key_column: InstrumentedAttribute,
+    present_keys: Set[Any],
+    window_days: Optional[int] = None,
+    settle_margin: Optional[timedelta] = None,
+    skip_score_states: Iterable[str] = ("PENDING_SCORE",),
+) -> int:
+    """Delete local rows in the reconcile window the API no longer returns.
+
+    Only ever call this with the keys from a **non-empty** fetch — an empty fetch
+    (e.g. a transient API blip) must not be read as "everything was deleted".
+
+    A row is deleted only when ALL of the following hold, so we never drop a
+    record that is merely settling or sitting just outside the fetched window:
+
+      * its natural key is absent from ``present_keys`` (what the API returned);
+      * its ``time_column`` is within ``[now - window, now - settle_margin]``;
+      * its ``score_state`` (if the model has one) is not still pending.
+
+    Args:
+        db: Active session (same transaction as the surrounding sync).
+        model: The ORM model class to reconcile.
+        user_id: Restrict to this user's rows.
+        time_column: Timestamp column defining the window (e.g. ``end_time``).
+        key_column: Natural-key column compared against ``present_keys``.
+        present_keys: Keys present in the API response for this poll.
+        window_days: Override the configured window (mainly for tests).
+        settle_margin: Override the configured settle margin (mainly for tests).
+        skip_score_states: score_state values that keep a row regardless.
+
+    Returns:
+        Number of rows deleted.
+    """
+    now = datetime.now(timezone.utc)
+    days = settings.reconcile_window_days if window_days is None else window_days
+    window_start = now - timedelta(days=days)
+    if settle_margin is None:
+        settle_margin = timedelta(minutes=settings.reconcile_settle_minutes)
+    cutoff = now - settle_margin
+
+    stmt = select(model).where(
+        model.user_id == user_id,
+        time_column >= window_start,
+        time_column <= cutoff,
+    )
+
+    has_score_state = hasattr(model, "score_state")
+    skip = set(skip_score_states)
+    key_attr = key_column.key
+
+    to_delete = []
+    for row in db.execute(stmt).scalars():
+        if has_score_state and row.score_state in skip:
+            continue
+        if getattr(row, key_attr) in present_keys:
+            continue
+        to_delete.append(row.id)
+
+    if not to_delete:
+        return 0
+
+    db.execute(sa_delete(model).where(model.id.in_(to_delete)))
+    logger.info(
+        "Reconciled deletions from Whoop",
+        model=model.__tablename__,
+        user_id=user_id,
+        deleted=len(to_delete),
+    )
+    return len(to_delete)

--- a/src/services/recovery_service.py
+++ b/src/services/recovery_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import RecoveryRecord, SyncStatus
 from src.database.session import get_db_context
+from src.services.reconcile import windowed_start, reconcile_deletes
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -117,10 +118,12 @@ class RecoveryService:
                 sync_status = db.execute(stmt).scalar_one_or_none()
 
                 if sync_status and sync_status.last_record_time:
-                    start = sync_status.last_record_time
+                    # Re-fetch a trailing overlap window so late rescores upsert.
+                    start = windowed_start(sync_status.last_record_time)
                     logger.info(
-                        "Using last sync time as start",
+                        "Using last sync time as start (overlap window applied)",
                         start=start.isoformat(),
+                        watermark=sync_status.last_record_time.isoformat(),
                     )
 
         try:
@@ -163,9 +166,19 @@ class RecoveryService:
                             recovery_score=db_record.get("recovery_score"),
                         )
 
-                        # Insert record (no natural unique ID from API, so we can't upsert)
-                        # Database will auto-generate UUID for id field
+                        # Upsert on the natural key (user_id, cycle_id). The API
+                        # gives no recovery id, but recovery is 1:1 with a cycle,
+                        # so re-fetched/rescored recoveries update in place instead
+                        # of inserting duplicates. id is omitted (DB-generated UUID
+                        # is preserved on conflict).
                         stmt = insert(RecoveryRecord).values(**db_record)
+                        stmt = stmt.on_conflict_do_update(
+                            index_elements=["user_id", "cycle_id"],
+                            set_={
+                                **db_record,
+                                "updated_at": datetime.now(timezone.utc),
+                            },
+                        )
 
                         db.execute(stmt)
                         records_synced += 1
@@ -180,6 +193,24 @@ class RecoveryService:
                             exc_info=True,
                         )
                         # Continue with other records
+
+                # Reconcile deletions: drop rows in the window the API no longer
+                # returns (a recovery deleted/rescored-away in the Whoop app).
+                # Keyed on cycle_id (recovery is 1:1 with a cycle; the API gives no
+                # recovery id). Skipped when api_records is empty (handled above).
+                present_keys = {
+                    r.get("cycle_id")
+                    for r in api_records
+                    if r.get("cycle_id") is not None
+                }
+                reconcile_deletes(
+                    db,
+                    RecoveryRecord,
+                    user_id=self.user_id,
+                    time_column=RecoveryRecord.created_at_whoop,
+                    key_column=RecoveryRecord.cycle_id,
+                    present_keys=present_keys,
+                )
 
                 # Get most recent record time for next sync
                 latest_record = max(

--- a/src/services/sleep_service.py
+++ b/src/services/sleep_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import SleepRecord, SyncStatus
 from src.database.session import get_db_context
+from src.services.reconcile import windowed_start, reconcile_deletes
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -132,10 +133,12 @@ class SleepService:
                 sync_status = db.execute(stmt).scalar_one_or_none()
 
                 if sync_status and sync_status.last_record_time:
-                    start = sync_status.last_record_time
+                    # Re-fetch a trailing overlap window so late rescores upsert.
+                    start = windowed_start(sync_status.last_record_time)
                     logger.info(
-                        "Using last sync time as start",
+                        "Using last sync time as start (overlap window applied)",
                         start=start.isoformat(),
+                        watermark=sync_status.last_record_time.isoformat(),
                     )
 
         try:
@@ -185,6 +188,20 @@ class SleepService:
                             exc_info=True,
                         )
                         # Continue with other records
+
+                # Reconcile deletions: drop rows in the window the API no longer
+                # returns (a record deleted in the Whoop app). Keyed on the stable
+                # sleep id. Skipped when api_records is empty (handled above), so a
+                # transient empty fetch can never wipe the window.
+                present_keys = {UUID(r["id"]) for r in api_records if r.get("id")}
+                reconcile_deletes(
+                    db,
+                    SleepRecord,
+                    user_id=self.user_id,
+                    time_column=SleepRecord.end_time,
+                    key_column=SleepRecord.id,
+                    present_keys=present_keys,
+                )
 
                 # Get most recent record time for next sync
                 latest_record = max(

--- a/src/services/workout_service.py
+++ b/src/services/workout_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import WorkoutRecord, SyncStatus
 from src.database.session import get_db_context
+from src.services.reconcile import windowed_start, reconcile_deletes
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -125,10 +126,12 @@ class WorkoutService:
                 sync_status = db.execute(stmt).scalar_one_or_none()
 
                 if sync_status and sync_status.last_record_time:
-                    start = sync_status.last_record_time
+                    # Re-fetch a trailing overlap window so late rescores upsert.
+                    start = windowed_start(sync_status.last_record_time)
                     logger.info(
-                        "Using last sync time as start",
+                        "Using last sync time as start (overlap window applied)",
                         start=start.isoformat(),
+                        watermark=sync_status.last_record_time.isoformat(),
                     )
 
         try:
@@ -178,6 +181,19 @@ class WorkoutService:
                             exc_info=True,
                         )
                         # Continue with other records
+
+                # Reconcile deletions: drop rows in the window the API no longer
+                # returns (a workout deleted in the Whoop app). Keyed on the stable
+                # workout id. Skipped when api_records is empty (handled above).
+                present_keys = {UUID(r["id"]) for r in api_records if r.get("id")}
+                reconcile_deletes(
+                    db,
+                    WorkoutRecord,
+                    user_id=self.user_id,
+                    time_column=WorkoutRecord.end_time,
+                    key_column=WorkoutRecord.id,
+                    present_keys=present_keys,
+                )
 
                 # Get most recent record time for next sync
                 latest_record = max(

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,190 @@
+"""Tests for windowed reconciliation (overlap window + delete-reconcile).
+
+Covers the two correctness gaps polling can't fix on its own:
+* late rescores -> overlap window re-fetch + idempotent upsert (no duplicates)
+* Whoop-side deletions -> delete-reconcile drops rows the API no longer returns,
+  with guards so settling / pending / out-of-window rows are never touched.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from src.api.whoop_client import WhoopClient
+from src.models.db_models import SleepRecord, RecoveryRecord, CycleRecord
+from src.services.recovery_service import RecoveryService
+from src.services.cycle_service import CycleService
+from src.services.reconcile import windowed_start, reconcile_deletes
+
+
+def _commit_on_exit(db_session):
+    """Mimic get_db_context: commit when the `with` block exits."""
+
+    def _exit(*args):
+        db_session.commit()
+        return None
+
+    return _exit
+
+
+def _make_sleep(db, user, *, end, score_state="SCORED", row_id=None):
+    rec = SleepRecord(
+        id=row_id or uuid4(),
+        user_id=user.id,
+        start_time=end - timedelta(hours=8),
+        end_time=end,
+        score_state=score_state,
+        raw_data={},
+    )
+    db.add(rec)
+    db.commit()
+    return rec
+
+
+# ============================================================================
+# windowed_start
+# ============================================================================
+
+@pytest.mark.unit
+class TestWindowedStart:
+    def test_subtracts_window(self):
+        t = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+        assert windowed_start(t, window_days=7) == t - timedelta(days=7)
+
+    def test_none_passthrough_preserves_full_backfill(self):
+        # First-ever sync has no watermark; must stay None (full backfill), not
+        # collapse to an empty/now-anchored window.
+        assert windowed_start(None) is None
+
+    def test_uses_configured_window_by_default(self):
+        from src.config import settings
+
+        t = datetime(2026, 6, 5, tzinfo=timezone.utc)
+        expected = t - timedelta(days=settings.reconcile_window_days)
+        assert windowed_start(t) == expected
+
+
+# ============================================================================
+# reconcile_deletes
+# ============================================================================
+
+@pytest.mark.unit
+class TestReconcileDeletes:
+    def test_deletes_in_window_row_absent_from_api(self, db_session, test_user):
+        now = datetime.now(timezone.utc)
+        keep = _make_sleep(db_session, test_user, end=now - timedelta(days=2))
+        drop = _make_sleep(db_session, test_user, end=now - timedelta(days=3))
+
+        deleted = reconcile_deletes(
+            db_session,
+            SleepRecord,
+            user_id=test_user.id,
+            time_column=SleepRecord.end_time,
+            key_column=SleepRecord.id,
+            present_keys={keep.id},  # `drop` is no longer returned by the API
+        )
+        db_session.commit()
+
+        assert deleted == 1
+        ids = {r.id for r in db_session.query(SleepRecord).all()}
+        assert keep.id in ids
+        assert drop.id not in ids
+
+    def test_guards_protect_recent_pending_and_out_of_window(self, db_session, test_user):
+        now = datetime.now(timezone.utc)
+        # Too recent (inside the settle margin) -> still settling, keep.
+        recent = _make_sleep(db_session, test_user, end=now - timedelta(minutes=10))
+        # Pending score -> API may briefly stop returning it; keep.
+        pending = _make_sleep(
+            db_session, test_user, end=now - timedelta(days=2), score_state="PENDING_SCORE"
+        )
+        # Older than the reconcile window -> not our concern this poll.
+        old = _make_sleep(db_session, test_user, end=now - timedelta(days=30))
+
+        # Empty present_keys = "API returned none of these"; guards must still hold.
+        deleted = reconcile_deletes(
+            db_session,
+            SleepRecord,
+            user_id=test_user.id,
+            time_column=SleepRecord.end_time,
+            key_column=SleepRecord.id,
+            present_keys=set(),
+        )
+        db_session.commit()
+
+        assert deleted == 0
+        ids = {r.id for r in db_session.query(SleepRecord).all()}
+        assert {recent.id, pending.id, old.id} <= ids
+
+    def test_present_row_is_kept(self, db_session, test_user):
+        now = datetime.now(timezone.utc)
+        present = _make_sleep(db_session, test_user, end=now - timedelta(days=2))
+
+        deleted = reconcile_deletes(
+            db_session,
+            SleepRecord,
+            user_id=test_user.id,
+            time_column=SleepRecord.end_time,
+            key_column=SleepRecord.id,
+            present_keys={present.id},
+        )
+
+        assert deleted == 0
+        assert db_session.query(SleepRecord).count() == 1
+
+
+# ============================================================================
+# Service-level idempotency (overlap re-fetch must not duplicate)
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestUpsertIdempotency:
+    async def test_recovery_resync_does_not_duplicate(
+        self, test_user, db_session, mock_whoop_recovery_response
+    ):
+        client = WhoopClient(user_id=test_user.id)
+        service = RecoveryService(user_id=test_user.id, whoop_client=client)
+        records = mock_whoop_recovery_response["records"]
+
+        with patch.object(
+            client, "get_recovery_records", new=AsyncMock(return_value=records)
+        ):
+            with patch("src.services.recovery_service.get_db_context") as mock_ctx:
+                mock_ctx.return_value.__enter__.return_value = db_session
+                mock_ctx.return_value.__exit__ = _commit_on_exit(db_session)
+
+                await service.sync_recovery_records()
+                await service.sync_recovery_records()  # overlap re-fetch
+
+        rows = (
+            db_session.query(RecoveryRecord)
+            .filter_by(user_id=test_user.id)
+            .all()
+        )
+        assert len(rows) == 1  # upserted on (user_id, cycle_id), not duplicated
+
+    async def test_cycle_resync_does_not_duplicate(
+        self, test_user, db_session, mock_whoop_cycle_response
+    ):
+        client = WhoopClient(user_id=test_user.id)
+        service = CycleService(user_id=test_user.id, whoop_client=client)
+        records = mock_whoop_cycle_response["records"]
+
+        with patch.object(
+            client, "get_cycle_records", new=AsyncMock(return_value=records)
+        ):
+            with patch("src.services.cycle_service.get_db_context") as mock_ctx:
+                mock_ctx.return_value.__enter__.return_value = db_session
+                mock_ctx.return_value.__exit__ = _commit_on_exit(db_session)
+
+                await service.sync_cycle_records()
+                await service.sync_cycle_records()  # overlap re-fetch
+
+        rows = (
+            db_session.query(CycleRecord)
+            .filter_by(user_id=test_user.id)
+            .all()
+        )
+        assert len(rows) == 1  # upserted on (user_id, whoop_cycle_id)


### PR DESCRIPTION
## Why

The webhooks plan (`docs/WEBHOOKS_PLAN.md`) existed to fix two data-correctness gaps that polling couldn't structurally solve: **silent deletions** and **missed late rescores**. But standing up a webhook receiver means a public endpoint + FastAPI/uvicorn + a Cloudflare Pro plan ($20/mo) for the WAF.

This PR closes both gaps with an **outbound-only reconciliation poll** instead — no inbound endpoint, no new service, no recurring cost. Webhooks are **completely deferred** (plan retained for reference only).

## What changed

### Fix the actual gaps (`src/services/reconcile.py`, all 4 time-series services)
- **Overlap window** — each poll re-fetches a trailing window (default 7d) by shifting the watermark back, so late rescores (`PENDING_SCORE → SCORED`, sleep-debt finalizing) upsert in place.
- **Delete-reconcile** — drops in-window rows Whoop no longer returns. Guards: skips rows newer than a settle margin (60m), skips `PENDING_SCORE`, and **never acts on an empty fetch** so an API blip can't wipe the window.
- First-ever sync still does a full backfill (`windowed_start(None) → None`).

### Prerequisite: stop recovery/cycle from duplicating
`recovery_records` and `cycle_records` had no natural-key upsert and re-inserted the boundary record every poll. Production had **3,210 duplicate recovery rows + 15 cycle rows** (which also inflated row-count stats).
- Added `UniqueConstraint(user_id, cycle_id)` (recovery) and `(user_id, whoop_cycle_id)` (cycle).
- Switched both services to `on_conflict_do_update`.
- Migration `c3d4e5f6a7b8` dedups existing rows (keeps newest per key) **then** adds the constraints.

Body measurements are intentionally untouched (deliberate change-history).

## Testing
- New `tests/unit/test_reconcile.py`: overlap-window math, delete-reconcile + all three guards, and recovery/cycle resync idempotency.
- Full suite: **145 passed, 1 skipped** (pre-existing skip).

## ⚠️ Deploy notes
- Migration **deletes** the duplicate rows (newest kept) — irreversible; `downgrade` drops the constraints but does not resurrect dupes. **Back up the DB before running it.**
- Migration was not run against the live DB here — that's owned by the Ansible/migration flow. It imports cleanly and chains onto head `b2c3d4e5f6a7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)