### PR TITLE
Harden auth, reconciliation, and API client per code review

### DIFF
--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -12,6 +12,7 @@ from alembic import command
 from alembic.config import Config
 
 from src.main import main as app_main
+from src.utils.logging_config import configure_logging
 
 
 def run_migrations() -> None:
@@ -20,6 +21,9 @@ def run_migrations() -> None:
 
 
 if __name__ == "__main__":
+    # Configure structured logging before anything emits log lines so migration
+    # and app output share one format and the third-party level overrides apply.
+    configure_logging()
     run_migrations()
     try:
         asyncio.run(app_main())

--- a/src/api/rate_limiter.py
+++ b/src/api/rate_limiter.py
@@ -41,8 +41,14 @@ class RateLimiter:
             max_requests_per_minute: Maximum requests per minute (from settings if None)
             safety_margin: Multiplier for max requests (0.9 = 90% of limit for safety)
         """
-        self.max_requests = int(
-            (max_requests_per_minute or settings.max_requests_per_minute) * safety_margin
+        # Guard against a config that floors to 0, which would make acquire()
+        # loop forever and get_stats() divide by zero.
+        self.max_requests = max(
+            1,
+            int(
+                (max_requests_per_minute or settings.max_requests_per_minute)
+                * safety_margin
+            ),
         )
         self.window_seconds = 60  # 1 minute window
         self.requests: deque[datetime] = deque()
@@ -64,51 +70,47 @@ class RateLimiter:
 
         This method should be called before every API request.
         """
-        async with self.lock:
-            now = datetime.now(timezone.utc)
+        # Loop so that after waiting we re-check capacity under the lock before
+        # recording. A single `if` would let several woken coroutines all append
+        # at once and overshoot max_requests.
+        while True:
+            async with self.lock:
+                now = datetime.now(timezone.utc)
 
-            # Remove timestamps outside the current window
-            self._cleanup_old_requests(now)
+                # Remove timestamps outside the current window
+                self._cleanup_old_requests(now)
 
-            # Check if we're at the limit
-            if len(self.requests) >= self.max_requests:
-                # Calculate how long to wait
-                oldest_request = self.requests[0]
-                window_start = now - timedelta(seconds=self.window_seconds)
+                if len(self.requests) < self.max_requests:
+                    # A slot is free: record it while still holding the lock so
+                    # no other coroutine can claim the same slot.
+                    self.requests.append(now)
 
-                if oldest_request > window_start:
-                    # We're at the limit, need to wait
-                    wait_time = (
-                        oldest_request - window_start
-                    ).total_seconds() + 0.1  # Add small buffer
-
-                    logger.warning(
-                        "Rate limit reached, waiting",
-                        wait_seconds=wait_time,
+                    logger.debug(
+                        "Rate limit acquired",
                         requests_in_window=len(self.requests),
                         max_requests=self.max_requests,
+                        utilization_percent=(len(self.requests) / self.max_requests)
+                        * 100,
                     )
+                    return
 
-                    # Release lock while waiting
-                    self.lock.release()
-                    try:
-                        await asyncio.sleep(wait_time)
-                    finally:
-                        await self.lock.acquire()
+                # At the limit: compute how long until the oldest request leaves
+                # the window, then release the lock (by exiting the `with`) and
+                # wait before retrying.
+                oldest_request = self.requests[0]
+                window_start = now - timedelta(seconds=self.window_seconds)
+                wait_time = (oldest_request - window_start).total_seconds() + 0.1
 
-                    # Re-clean after waiting
-                    now = datetime.now(timezone.utc)
-                    self._cleanup_old_requests(now)
+                logger.warning(
+                    "Rate limit reached, waiting",
+                    wait_seconds=wait_time,
+                    requests_in_window=len(self.requests),
+                    max_requests=self.max_requests,
+                )
 
-            # Record this request
-            self.requests.append(now)
-
-            logger.debug(
-                "Rate limit acquired",
-                requests_in_window=len(self.requests),
-                max_requests=self.max_requests,
-                utilization_percent=(len(self.requests) / self.max_requests) * 100,
-            )
+            # Lock released here. Sleep outside the lock so other coroutines can
+            # make progress, then loop to re-acquire and re-check.
+            await asyncio.sleep(max(wait_time, 0))
 
     def _cleanup_old_requests(self, now: datetime) -> None:
         """

--- a/src/api/whoop_client.py
+++ b/src/api/whoop_client.py
@@ -5,10 +5,8 @@ supporting sleep, workout, recovery, and cycle data with pagination,
 rate limiting, and automatic token refresh.
 """
 
-import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional, List, Dict, Any, AsyncIterator
-from urllib.parse import urlencode
 
 import httpx
 from tenacity import (
@@ -32,6 +30,45 @@ class WhoopAPIError(Exception):
     def __init__(self, message: str, status_code: Optional[int] = None):
         self.status_code = status_code
         super().__init__(message)
+
+
+class WhoopRetryableError(WhoopAPIError):
+    """A transient API error (429 / 5xx) that should be retried."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        retry_after: Optional[float] = None,
+    ):
+        super().__init__(message, status_code)
+        self.retry_after = retry_after
+
+
+# HTTP statuses worth retrying: rate limiting and transient server errors.
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# Fallback backoff when the server doesn't tell us how long to wait.
+_EXP_WAIT = wait_exponential(multiplier=1, min=2, max=10)
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a Retry-After header (delta-seconds form). HTTP-date form -> None."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        # HTTP-date form is not handled; caller falls back to exponential backoff.
+        return None
+
+
+def _whoop_retry_wait(retry_state) -> float:
+    """Honor a server-provided Retry-After, else exponential backoff."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, WhoopRetryableError) and exc.retry_after is not None:
+        return min(exc.retry_after, 60.0)  # cap to avoid pathologically long waits
+    return _EXP_WAIT(retry_state)
 
 
 class WhoopClient:
@@ -70,12 +107,38 @@ class WhoopClient:
         self.rate_limiter = rate_limiter or RateLimiter()
         self.base_url = settings.whoop_api_base_url
         self.timeout = timeout
+        # Lazily-created, reused across requests for connection pooling/keep-alive.
+        # Closed via aclose() (or the async context manager).
+        self._client: Optional[httpx.AsyncClient] = None
 
         logger.info(
             "Whoop client initialized",
             user_id=user_id,
             base_url=self.base_url,
         )
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the shared AsyncClient, creating it on first use."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=self.timeout,
+                limits=httpx.Limits(
+                    max_connections=10, max_keepalive_connections=5
+                ),
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the shared HTTP client and release pooled connections."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+
+    async def __aenter__(self) -> "WhoopClient":
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()
 
     async def _get_headers(self) -> Dict[str, str]:
         """
@@ -99,8 +162,10 @@ class WhoopClient:
 
     @retry(
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+        wait=_whoop_retry_wait,
+        retry=retry_if_exception_type(
+            (httpx.TimeoutException, httpx.NetworkError, WhoopRetryableError)
+        ),
         reraise=True,
     )
     async def _make_request(
@@ -136,30 +201,46 @@ class WhoopClient:
         )
 
         try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.get(url, headers=headers, params=params)
-                response.raise_for_status()
+            client = self._get_client()
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
 
-                data = response.json()
+            data = response.json()
 
-                logger.debug(
-                    "API request successful",
-                    endpoint=endpoint,
-                    status_code=response.status_code,
-                )
+            logger.debug(
+                "API request successful",
+                endpoint=endpoint,
+                status_code=response.status_code,
+            )
 
-                return data
+            return data
 
         except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code
+            # Log status only — never the response body, which can echo request
+            # context / sensitive data.
+            if status_code in _RETRYABLE_STATUS_CODES:
+                retry_after = _parse_retry_after(e.response.headers.get("Retry-After"))
+                logger.warning(
+                    "Retryable API error, will retry",
+                    endpoint=endpoint,
+                    status_code=status_code,
+                    retry_after=retry_after,
+                )
+                raise WhoopRetryableError(
+                    f"Retryable API error (status {status_code})",
+                    status_code=status_code,
+                    retry_after=retry_after,
+                )
+
             logger.error(
                 "API request failed",
                 endpoint=endpoint,
-                status_code=e.response.status_code,
-                error=e.response.text,
+                status_code=status_code,
             )
             raise WhoopAPIError(
-                f"API request failed: {e.response.text}",
-                status_code=e.response.status_code,
+                f"API request failed with status {status_code}",
+                status_code=status_code,
             )
         except (httpx.TimeoutException, httpx.NetworkError) as e:
             logger.warning(

--- a/src/auth/oauth_client.py
+++ b/src/auth/oauth_client.py
@@ -5,7 +5,6 @@ for secure authentication with the Whoop API.
 """
 
 import secrets
-import hashlib
 import base64
 from typing import Optional, Dict, Any
 from urllib.parse import urlencode
@@ -188,11 +187,12 @@ class WhoopOAuthClient:
                 return token_data
 
         except httpx.HTTPStatusError as e:
+            # Log status only. The response body and exc_info (which carries the
+            # request, including client_secret/code/code_verifier) are withheld
+            # to avoid leaking secrets into logs.
             logger.error(
                 "Token exchange failed",
                 status_code=e.response.status_code,
-                error=e.response.text,
-                exc_info=True,
             )
             raise
         except Exception as e:
@@ -252,11 +252,12 @@ class WhoopOAuthClient:
                 return token_data
 
         except httpx.HTTPStatusError as e:
+            # Log status only. The response body and exc_info (which carries the
+            # request, including client_secret/refresh_token) are withheld to
+            # avoid leaking secrets into logs.
             logger.error(
                 "Token refresh failed",
                 status_code=e.response.status_code,
-                error=e.response.text,
-                exc_info=True,
             )
             raise
         except Exception as e:

--- a/src/auth/token_manager.py
+++ b/src/auth/token_manager.py
@@ -4,19 +4,28 @@ This module handles storage, retrieval, and automatic refresh of OAuth tokens
 in the PostgreSQL database with encryption at rest.
 """
 
+import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from src.models.db_models import User, OAuthToken
+from src.models.db_models import OAuthToken
 from src.auth.oauth_client import WhoopOAuthClient
 from src.auth.encryption import get_token_encryption
 from src.database.session import get_db_context
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+class _TokenState(NamedTuple):
+    """Decrypted snapshot of a stored token, used to decide on refresh."""
+
+    access_token: str
+    refresh_token: str
+    expires_at: datetime
 
 
 class TokenManager:
@@ -30,6 +39,23 @@ class TokenManager:
         oauth_client: OAuth client for token refresh operations
         refresh_threshold: Time before expiry to trigger refresh (minutes)
     """
+
+    # Per-user refresh locks, shared across all TokenManager instances in the
+    # process. Whoop rotates the refresh token on every refresh, so two
+    # concurrent refreshes for one user would race: the second presents an
+    # already-consumed refresh token and can revoke the grant. Serializing per
+    # user (the event loop is single-threaded, so get-or-create is atomic
+    # between awaits) ensures only one in-flight refresh per user.
+    _refresh_locks: dict[int, asyncio.Lock] = {}
+
+    @classmethod
+    def _get_refresh_lock(cls, user_id: int) -> asyncio.Lock:
+        """Return the process-wide refresh lock for a user, creating it once."""
+        lock = cls._refresh_locks.get(user_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._refresh_locks[user_id] = lock
+        return lock
 
     def __init__(
         self,
@@ -145,7 +171,9 @@ class TokenManager:
         """
         Get a valid access token for the user.
 
-        Automatically refreshes token if it's near expiration.
+        Automatically refreshes token if it's near expiration. Refreshes are
+        serialized per user (see ``_refresh_locks``) so concurrent callers
+        never each spend the rotating refresh token.
 
         Args:
             user_id: User database ID
@@ -157,114 +185,132 @@ class TokenManager:
         Raises:
             Exception: If token refresh fails
         """
+        # Fast path: read current state without taking the refresh lock.
+        state = self._read_token_state(user_id, db)
+        if state is None:
+            logger.warning("No token found for user", user_id=user_id)
+            return None
 
-        def _get_token_sync(session: Session) -> Optional[str]:
-            # Get encryption instance
-            encryption = get_token_encryption()
+        now = datetime.now(timezone.utc)
+        if state.expires_at - now > self.refresh_threshold:
+            return state.access_token
 
-            # Retrieve user's token from database
-            stmt = select(OAuthToken).where(OAuthToken.user_id == user_id)
-            token = session.execute(stmt).scalar_one_or_none()
-
-            if not token:
-                logger.warning("No token found for user", user_id=user_id)
+        # Near expiry: serialize refresh per user. The lock holder refreshes;
+        # everyone else falls through to the freshly-stored token below.
+        async with self._get_refresh_lock(user_id):
+            # Double-checked: another caller may have refreshed while we waited.
+            state = self._read_token_state(user_id, db)
+            if state is None:
                 return None
+            now = datetime.now(timezone.utc)
+            if state.expires_at - now > self.refresh_threshold:
+                logger.info(
+                    "Token refreshed by a concurrent caller; reusing",
+                    user_id=user_id,
+                )
+                return state.access_token
 
-            # Decrypt tokens
+            logger.info(
+                "Token near expiration, refreshing",
+                user_id=user_id,
+                time_until_expiry_seconds=(state.expires_at - now).total_seconds(),
+            )
+
             try:
-                decrypted_access_token = encryption.decrypt(token.access_token)
-                decrypted_refresh_token = encryption.decrypt(token.refresh_token)
+                token_data = await self.oauth_client.refresh_access_token(
+                    state.refresh_token
+                )
             except Exception as e:
                 logger.error(
-                    "Failed to decrypt token",
+                    "Failed to refresh token",
                     user_id=user_id,
                     error=str(e),
+                    exc_info=True,
                 )
                 raise
 
-            # Check if token needs refresh
-            now = datetime.now(timezone.utc)
-            # Handle both timezone-aware and naive datetimes (SQLite may strip timezone)
-            token_expiry = token.expires_at
-            if token_expiry.tzinfo is None:
-                # If token is naive, make it UTC-aware
-                token_expiry = token_expiry.replace(tzinfo=timezone.utc)
-            time_until_expiry = token_expiry - now
+            # Validate the response before mutating any stored state, so a
+            # malformed 200 can't leave the row half-updated.
+            if not token_data.get("access_token") or token_data.get("expires_in") is None:
+                raise ValueError("Token refresh response missing access_token/expires_in")
 
-            if time_until_expiry <= self.refresh_threshold:
-                logger.info(
-                    "Token near expiration, refreshing",
-                    user_id=user_id,
-                    time_until_expiry_seconds=time_until_expiry.total_seconds(),
-                )
+            return self._store_refreshed_token(
+                user_id, token_data, state.refresh_token, db
+            )
 
-                # Refresh token asynchronously
-                import asyncio
-                import concurrent.futures
+    def _read_token_state(
+        self,
+        user_id: int,
+        db: Optional[Session] = None,
+    ) -> Optional[_TokenState]:
+        """Read and decrypt the stored token into a snapshot (no refresh)."""
 
-                try:
-                    # Check if there's a running event loop (e.g., in async tests)
-                    try:
-                        loop = asyncio.get_running_loop()
-                        # If loop is running, we need to run the async code in a thread pool
-                        with concurrent.futures.ThreadPoolExecutor() as executor:
-                            future = executor.submit(
-                                asyncio.run,
-                                self.oauth_client.refresh_access_token(decrypted_refresh_token)
-                            )
-                            token_data = future.result()
-                    except RuntimeError:
-                        # No running loop, we can use run_until_complete
-                        loop = asyncio.new_event_loop()
-                        asyncio.set_event_loop(loop)
-                        token_data = loop.run_until_complete(
-                            self.oauth_client.refresh_access_token(decrypted_refresh_token)
-                        )
+        def _read(session: Session) -> Optional[_TokenState]:
+            encryption = get_token_encryption()
+            stmt = select(OAuthToken).where(OAuthToken.user_id == user_id)
+            token = session.execute(stmt).scalar_one_or_none()
+            if not token:
+                return None
 
-                    # Encrypt new tokens before updating database
-                    encrypted_access_token = encryption.encrypt(token_data["access_token"])
-                    encrypted_refresh_token = encryption.encrypt(
-                        token_data.get("refresh_token", decrypted_refresh_token)
-                    )
+            try:
+                access = encryption.decrypt(token.access_token)
+                refresh = encryption.decrypt(token.refresh_token)
+            except Exception as e:
+                logger.error("Failed to decrypt token", user_id=user_id, error=str(e))
+                raise
 
-                    # Update token in database with encrypted values
-                    token.access_token = encrypted_access_token
-                    token.refresh_token = encrypted_refresh_token
-                    token.token_type = token_data.get("token_type", token.token_type)
-                    token.expires_at = datetime.now(timezone.utc) + timedelta(
-                        seconds=token_data["expires_in"]
-                    )
-                    token.updated_at = datetime.now(timezone.utc)
+            # Handle both tz-aware and naive datetimes (SQLite may strip tzinfo).
+            expiry = token.expires_at
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=timezone.utc)
+            return _TokenState(access, refresh, expiry)
 
-                    session.commit()
-
-                    logger.info(
-                        "Token refreshed successfully (encrypted)",
-                        user_id=user_id,
-                        new_expires_at=token.expires_at.isoformat(),
-                    )
-
-                    # Return the new decrypted access token
-                    return token_data["access_token"]
-
-                except Exception as e:
-                    logger.error(
-                        "Failed to refresh token",
-                        user_id=user_id,
-                        error=str(e),
-                        exc_info=True,
-                    )
-                    raise
-
-            # Return decrypted access token
-            return decrypted_access_token
-
-        # Use provided session or create new one
         if db:
-            return _get_token_sync(db)
-        else:
-            with get_db_context() as session:
-                return _get_token_sync(session)
+            return _read(db)
+        with get_db_context() as session:
+            return _read(session)
+
+    def _store_refreshed_token(
+        self,
+        user_id: int,
+        token_data: dict,
+        current_refresh_token: str,
+        db: Optional[Session] = None,
+    ) -> str:
+        """Persist a refreshed token (encrypted) and return the new access token."""
+        encryption = get_token_encryption()
+        new_access_token = token_data["access_token"]
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=token_data["expires_in"]
+        )
+
+        def _store(session: Session) -> str:
+            stmt = select(OAuthToken).where(OAuthToken.user_id == user_id)
+            token = session.execute(stmt).scalar_one_or_none()
+            if not token:
+                raise ValueError(f"Token disappeared during refresh (user {user_id})")
+
+            token.access_token = encryption.encrypt(new_access_token)
+            # Whoop rotates the refresh token; fall back to the current one if absent.
+            token.refresh_token = encryption.encrypt(
+                token_data.get("refresh_token", current_refresh_token)
+            )
+            token.token_type = token_data.get("token_type", token.token_type)
+            token.expires_at = expires_at
+            token.updated_at = datetime.now(timezone.utc)
+            session.commit()
+
+            logger.info(
+                "Token refreshed successfully (encrypted)",
+                user_id=user_id,
+                new_expires_at=expires_at.isoformat(),
+            )
+            return new_access_token
+
+        if db:
+            return _store(db)
+        with get_db_context() as session:
+            return _store(session)
 
     async def is_token_valid(
         self,

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -3,7 +3,7 @@
 from contextlib import contextmanager
 from typing import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import NullPool
 
@@ -96,7 +96,8 @@ def check_connection() -> bool:
     """
     try:
         with engine.connect() as conn:
-            conn.execute("SELECT 1")
+            # SQLAlchemy 2.0 requires an executable clause, not a bare string.
+            conn.execute(text("SELECT 1"))
         logger.info("Database connection successful")
         return True
     except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -7,12 +7,11 @@ the scheduler for periodic data synchronization.
 import asyncio
 import signal
 import sys
-from typing import Optional
 
 from src.config import settings
 from src.database.init_db import init_database
-from src.scheduler.job_scheduler import initialize_scheduler, get_scheduler
-from src.utils.logging_config import get_logger
+from src.scheduler.job_scheduler import initialize_scheduler
+from src.utils.logging_config import configure_logging, get_logger
 
 logger = get_logger(__name__)
 
@@ -145,6 +144,10 @@ async def main() -> None:
 
     Creates and runs the application.
     """
+    # Idempotent: also called in scripts/entrypoint.py before migrations. Ensures
+    # logging is configured for `python -m src.main` and any other caller path.
+    configure_logging()
+
     logger.info(
         "Whoopster starting",
         version="1.0.0",

--- a/src/services/cycle_service.py
+++ b/src/services/cycle_service.py
@@ -5,12 +5,10 @@ transforming them to database models, and performing upsert operations.
 """
 
 from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
-from uuid import UUID
+from typing import Optional, Dict, Any
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
 
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import CycleRecord, SyncStatus
@@ -140,11 +138,13 @@ class CycleService:
 
             if not api_records:
                 logger.info("No cycle records to sync", user_id=self.user_id)
+                # Leave the watermark untouched on an empty fetch (see sleep
+                # service): writing the backdated `start` would regress it.
                 self._update_sync_status(
                     status="success",
                     records_fetched=0,
                     last_sync_time=datetime.now(timezone.utc),
-                    last_record_time=start,
+                    last_record_time=None,
                 )
                 return 0
 
@@ -203,6 +203,8 @@ class CycleService:
                     time_column=CycleRecord.end_time,
                     key_column=CycleRecord.whoop_cycle_id,
                     present_keys=present_keys,
+                    fetch_start=start,
+                    fetch_end=end,
                 )
 
                 # Get most recent record time for next sync (from completed cycles only)
@@ -218,7 +220,10 @@ class CycleService:
                         latest_record["end"].replace("Z", "+00:00")
                     )
                 else:
-                    latest_time = start or datetime.now(timezone.utc)
+                    # Only ongoing cycles this poll: don't move the watermark
+                    # (None leaves it unchanged), rather than regressing to the
+                    # backdated overlap `start`.
+                    latest_time = None
 
             # Update sync status
             self._update_sync_status(

--- a/src/services/data_collector.py
+++ b/src/services/data_collector.py
@@ -342,4 +342,8 @@ async def sync_user_data(user_id: int) -> Dict[str, Any]:
         Sync results dictionary
     """
     collector = DataCollector(user_id)
-    return await collector.sync_all_data()
+    try:
+        return await collector.sync_all_data()
+    finally:
+        # Release pooled HTTP connections held for this sync run.
+        await collector.whoop_client.aclose()

--- a/src/services/reconcile.py
+++ b/src/services/reconcile.py
@@ -30,6 +30,15 @@ from src.utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Normalize a datetime to tz-aware UTC so window comparisons are safe."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def windowed_start(
     last_record_time: Optional[datetime],
     window_days: Optional[int] = None,
@@ -63,6 +72,8 @@ def reconcile_deletes(
     present_keys: Set[Any],
     window_days: Optional[int] = None,
     settle_margin: Optional[timedelta] = None,
+    fetch_start: Optional[datetime] = None,
+    fetch_end: Optional[datetime] = None,
     skip_score_states: Iterable[str] = ("PENDING_SCORE",),
 ) -> int:
     """Delete local rows in the reconcile window the API no longer returns.
@@ -73,8 +84,10 @@ def reconcile_deletes(
     A row is deleted only when ALL of the following hold, so we never drop a
     record that is merely settling or sitting just outside the fetched window:
 
-      * its natural key is absent from ``present_keys`` (what the API returned);
-      * its ``time_column`` is within ``[now - window, now - settle_margin]``;
+      * its natural key is non-null and absent from ``present_keys``;
+      * its ``time_column`` is within ``[now - window, now - settle_margin]``,
+        further clamped to the actually-fetched ``[fetch_start, fetch_end]`` so a
+        bounded/backfill fetch is never treated as authoritative beyond its range;
       * its ``score_state`` (if the model has one) is not still pending.
 
     Args:
@@ -86,6 +99,10 @@ def reconcile_deletes(
         present_keys: Keys present in the API response for this poll.
         window_days: Override the configured window (mainly for tests).
         settle_margin: Override the configured settle margin (mainly for tests).
+        fetch_start: Lower bound actually sent to the API (the windowed start).
+            Rows below it weren't requested, so the window is clamped up to it.
+        fetch_end: Upper bound actually sent to the API, if any. Rows above it
+            weren't requested, so the cutoff is clamped down to it.
         skip_score_states: score_state values that keep a row regardless.
 
     Returns:
@@ -97,6 +114,18 @@ def reconcile_deletes(
     if settle_margin is None:
         settle_margin = timedelta(minutes=settings.reconcile_settle_minutes)
     cutoff = now - settle_margin
+
+    # Clamp the reconcile window to what was actually fetched. Without this, an
+    # explicit `end` (or a `start` newer than the default window) would let us
+    # delete rows in a range the API was never asked about.
+    fetch_start = _as_utc(fetch_start)
+    fetch_end = _as_utc(fetch_end)
+    if fetch_start is not None and fetch_start > window_start:
+        window_start = fetch_start
+    if fetch_end is not None and fetch_end < cutoff:
+        cutoff = fetch_end
+    if window_start > cutoff:
+        return 0
 
     stmt = select(model).where(
         model.user_id == user_id,
@@ -112,7 +141,10 @@ def reconcile_deletes(
     for row in db.execute(stmt).scalars():
         if has_score_state and row.score_state in skip:
             continue
-        if getattr(row, key_attr) in present_keys:
+        key_value = getattr(row, key_attr)
+        # A null natural key can never match the API response, so it would always
+        # look "deleted". Keep it rather than dropping a row we can't reconcile.
+        if key_value is None or key_value in present_keys:
             continue
         to_delete.append(row.id)
 

--- a/src/services/recovery_service.py
+++ b/src/services/recovery_service.py
@@ -5,12 +5,11 @@ transforming them to database models, and performing upsert operations.
 """
 
 from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
+from typing import Optional, Dict, Any
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
 
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import RecoveryRecord, SyncStatus
@@ -135,11 +134,13 @@ class RecoveryService:
 
             if not api_records:
                 logger.info("No recovery records to sync", user_id=self.user_id)
+                # Leave the watermark untouched on an empty fetch (see sleep
+                # service): writing the backdated `start` would regress it.
                 self._update_sync_status(
                     status="success",
                     records_fetched=0,
                     last_sync_time=datetime.now(timezone.utc),
-                    last_record_time=start,
+                    last_record_time=None,
                 )
                 return 0
 
@@ -149,12 +150,11 @@ class RecoveryService:
             with get_db_context() as db:
                 for idx, api_record in enumerate(api_records):
                     try:
-                        # Log first record for debugging
+                        # Log only field names (no health values/PII) at debug.
                         if idx == 0:
-                            logger.info(
-                                "Sample recovery API record",
+                            logger.debug(
+                                "Recovery API record fields",
                                 api_record_keys=list(api_record.keys()),
-                                sample_data=api_record,
                             )
 
                         # Transform API record to database format
@@ -210,6 +210,8 @@ class RecoveryService:
                     time_column=RecoveryRecord.created_at_whoop,
                     key_column=RecoveryRecord.cycle_id,
                     present_keys=present_keys,
+                    fetch_start=start,
+                    fetch_end=end,
                 )
 
                 # Get most recent record time for next sync

--- a/src/services/sleep_service.py
+++ b/src/services/sleep_service.py
@@ -5,12 +5,11 @@ transforming them to database models, and performing upsert operations.
 """
 
 from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
+from typing import Optional, Dict, Any
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
 
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import SleepRecord, SyncStatus
@@ -150,11 +149,14 @@ class SleepService:
 
             if not api_records:
                 logger.info("No sleep records to sync", user_id=self.user_id)
+                # Leave the watermark untouched on an empty fetch. Writing the
+                # backdated overlap `start` here would walk the watermark 7 days
+                # into the past on every empty poll.
                 self._update_sync_status(
                     status="success",
                     records_fetched=0,
                     last_sync_time=datetime.now(timezone.utc),
-                    last_record_time=start,
+                    last_record_time=None,
                 )
                 return 0
 
@@ -201,6 +203,8 @@ class SleepService:
                     time_column=SleepRecord.end_time,
                     key_column=SleepRecord.id,
                     present_keys=present_keys,
+                    fetch_start=start,
+                    fetch_end=end,
                 )
 
                 # Get most recent record time for next sync

--- a/src/services/workout_service.py
+++ b/src/services/workout_service.py
@@ -5,12 +5,11 @@ transforming them to database models, and performing upsert operations.
 """
 
 from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
+from typing import Optional, Dict, Any
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
 
 from src.api.whoop_client import WhoopClient
 from src.models.db_models import WorkoutRecord, SyncStatus
@@ -143,11 +142,13 @@ class WorkoutService:
 
             if not api_records:
                 logger.info("No workout records to sync", user_id=self.user_id)
+                # Leave the watermark untouched on an empty fetch (see sleep
+                # service): writing the backdated `start` would regress it.
                 self._update_sync_status(
                     status="success",
                     records_fetched=0,
                     last_sync_time=datetime.now(timezone.utc),
-                    last_record_time=start,
+                    last_record_time=None,
                 )
                 return 0
 
@@ -193,6 +194,8 @@ class WorkoutService:
                     time_column=WorkoutRecord.end_time,
                     key_column=WorkoutRecord.id,
                     present_keys=present_keys,
+                    fetch_start=start,
+                    fetch_end=end,
                 )
 
                 # Get most recent record time for next sync

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -2,9 +2,23 @@
 
 import pytest
 import asyncio
+from collections import deque
 from datetime import datetime, timezone, timedelta
 
-from src.api.rate_limiter import RateLimiter, RateLimitExceeded
+from src.api.rate_limiter import RateLimiter
+
+
+class _PeakDeque(deque):
+    """A deque that records the maximum length ever reached."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.peak = 0
+
+    def append(self, item):
+        super().append(item)
+        if len(self) > self.peak:
+            self.peak = len(self)
 
 
 @pytest.mark.unit
@@ -136,6 +150,35 @@ class TestRateLimiter:
 
         stats = await limiter.get_stats()
         assert stats["requests_in_window"] == 15
+
+    async def test_never_overshoots_max_under_concurrency(self):
+        """Concurrent acquirers must never push the window past max_requests.
+
+        The old code used an `if` (not a loop) and released/re-acquired the lock
+        by hand, so several waiters could wake and all append at once, exceeding
+        the limit. With a short window this reproduces quickly; the recorded
+        peak length must stay within max_requests.
+        """
+        limiter = RateLimiter(max_requests_per_minute=2, safety_margin=1.0)
+        assert limiter.max_requests == 2
+        limiter.window_seconds = 1  # shrink the window so waits are sub-second
+        limiter.requests = _PeakDeque()
+
+        now = datetime.now(timezone.utc)
+        # Fill to the limit with entries that are still inside the 1s window.
+        limiter.requests.append(now - timedelta(seconds=0.9))
+        limiter.requests.append(now - timedelta(seconds=0.1))
+
+        # Three concurrent acquirers contend for slots as the old entries expire.
+        await asyncio.gather(*[limiter.acquire() for _ in range(3)])
+
+        assert limiter.requests.peak <= limiter.max_requests
+        assert len(limiter.requests) <= limiter.max_requests
+
+    async def test_max_requests_floors_to_at_least_one(self):
+        """A tiny config must not floor max_requests to 0 (infinite loop / div0)."""
+        limiter = RateLimiter(max_requests_per_minute=1, safety_margin=0.1)
+        assert limiter.max_requests == 1  # int(0.1) == 0, clamped up to 1
 
     async def test_custom_safety_margin(self):
         """Test custom safety margin."""

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -12,9 +12,10 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 from src.api.whoop_client import WhoopClient
-from src.models.db_models import SleepRecord, RecoveryRecord, CycleRecord
+from src.models.db_models import SleepRecord, RecoveryRecord, CycleRecord, SyncStatus
 from src.services.recovery_service import RecoveryService
 from src.services.cycle_service import CycleService
+from src.services.sleep_service import SleepService
 from src.services.reconcile import windowed_start, reconcile_deletes
 
 
@@ -132,6 +133,120 @@ class TestReconcileDeletes:
 
         assert deleted == 0
         assert db_session.query(SleepRecord).count() == 1
+
+    def test_keeps_row_with_null_natural_key(self, db_session, test_user):
+        # A recovery whose cycle_id is NULL can never match present_keys, so it
+        # would always look "deleted". It must be kept, not dropped.
+        now = datetime.now(timezone.utc)
+        rec = RecoveryRecord(
+            id=uuid4(),
+            user_id=test_user.id,
+            cycle_id=None,
+            created_at_whoop=now - timedelta(days=2),
+            score_state="SCORED",
+            raw_data={},
+        )
+        db_session.add(rec)
+        db_session.commit()
+
+        deleted = reconcile_deletes(
+            db_session,
+            RecoveryRecord,
+            user_id=test_user.id,
+            time_column=RecoveryRecord.created_at_whoop,
+            key_column=RecoveryRecord.cycle_id,
+            present_keys=set(),  # API returned nothing for this key
+        )
+        db_session.commit()
+
+        assert deleted == 0
+        assert db_session.query(RecoveryRecord).count() == 1
+
+    def test_fetch_end_clamps_window_above_fetched_range(self, db_session, test_user):
+        # A bounded fetch (end = now-2d) never asked about a row at now-1d, so
+        # that row must not be deleted even though it's absent from present_keys.
+        now = datetime.now(timezone.utc)
+        recent = _make_sleep(db_session, test_user, end=now - timedelta(days=1))
+
+        deleted = reconcile_deletes(
+            db_session,
+            SleepRecord,
+            user_id=test_user.id,
+            time_column=SleepRecord.end_time,
+            key_column=SleepRecord.id,
+            present_keys=set(),
+            fetch_end=now - timedelta(days=2),
+        )
+        db_session.commit()
+
+        assert deleted == 0
+        assert recent.id in {r.id for r in db_session.query(SleepRecord).all()}
+
+    def test_fetch_start_clamps_window_below_fetched_range(self, db_session, test_user):
+        # A fetch that only started at now-2d never asked about a row at now-5d
+        # (inside the default 7d window), so that row must not be deleted.
+        now = datetime.now(timezone.utc)
+        old = _make_sleep(db_session, test_user, end=now - timedelta(days=5))
+
+        deleted = reconcile_deletes(
+            db_session,
+            SleepRecord,
+            user_id=test_user.id,
+            time_column=SleepRecord.end_time,
+            key_column=SleepRecord.id,
+            present_keys=set(),
+            fetch_start=now - timedelta(days=2),
+        )
+        db_session.commit()
+
+        assert deleted == 0
+        assert old.id in {r.id for r in db_session.query(SleepRecord).all()}
+
+
+# ============================================================================
+# Empty-fetch must not regress the watermark
+# ============================================================================
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEmptyFetchWatermark:
+    async def test_empty_fetch_leaves_watermark_unchanged(self, test_user, db_session):
+        # Seed a known watermark, then sync an empty API response. The watermark
+        # must stay put — not regress by the overlap window (the old bug wrote
+        # the backdated `start`, walking it 7 days into the past every poll).
+        watermark = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        db_session.add(
+            SyncStatus(
+                user_id=test_user.id,
+                data_type="sleep",
+                status="success",
+                last_record_time=watermark,
+                records_fetched=1,
+            )
+        )
+        db_session.commit()
+
+        client = WhoopClient(user_id=test_user.id)
+        service = SleepService(user_id=test_user.id, whoop_client=client)
+
+        with patch.object(
+            client, "get_sleep_records", new=AsyncMock(return_value=[])
+        ):
+            with patch("src.services.sleep_service.get_db_context") as mock_ctx:
+                mock_ctx.return_value.__enter__.return_value = db_session
+                mock_ctx.return_value.__exit__ = _commit_on_exit(db_session)
+
+                await service.sync_sleep_records()
+
+        ss = (
+            db_session.query(SyncStatus)
+            .filter_by(user_id=test_user.id, data_type="sleep")
+            .one()
+        )
+        got = ss.last_record_time
+        if got.tzinfo is None:  # SQLite may strip tzinfo
+            got = got.replace(tzinfo=timezone.utc)
+        assert got == watermark
 
 
 # ============================================================================

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,29 @@
+"""Tests for database session helpers."""
+
+import pytest
+from sqlalchemy import create_engine
+
+import src.database.session as session_module
+
+
+@pytest.mark.unit
+def test_check_connection_succeeds(monkeypatch):
+    """check_connection must run a real, executable statement.
+
+    Regression: it previously passed a bare ``"SELECT 1"`` string, which raises
+    under SQLAlchemy 2.0 and made the function always return False.
+    """
+    test_engine = create_engine("sqlite://")
+    monkeypatch.setattr(session_module, "engine", test_engine)
+
+    assert session_module.check_connection() is True
+
+
+@pytest.mark.unit
+def test_check_connection_failure_returns_false(monkeypatch):
+    """A broken connection is reported as False, not raised."""
+    # Point at an unreachable driver target so connect() fails fast.
+    bad_engine = create_engine("sqlite:////nonexistent/path/does/not/exist.db")
+    monkeypatch.setattr(session_module, "engine", bad_engine)
+
+    assert session_module.check_connection() is False

--- a/tests/unit/test_token_manager.py
+++ b/tests/unit/test_token_manager.py
@@ -1,5 +1,7 @@
 """Tests for token manager."""
 
+import asyncio
+
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, patch
@@ -144,6 +146,87 @@ class TestTokenManagerAsync:
             # Check database was updated with encrypted token
             db_session.refresh(near_expiry_token)
             assert encryption.decrypt(near_expiry_token.access_token) == "new_access"
+
+    async def test_concurrent_refresh_happens_once(self, db_session, test_user):
+        """Concurrent near-expiry callers must trigger exactly one refresh.
+
+        Whoop rotates the refresh token, so a second concurrent refresh would
+        present a consumed token. The per-user lock + double-check must collapse
+        N concurrent callers into a single refresh, with the rest reusing it.
+        """
+        manager = TokenManager()
+        encryption = get_token_encryption()
+
+        near_expiry_token = OAuthToken(
+            user_id=test_user.id,
+            access_token=encryption.encrypt("old_access"),
+            refresh_token=encryption.encrypt("old_refresh"),
+            token_type="Bearer",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            scopes=["read:sleep"],
+        )
+        db_session.add(near_expiry_token)
+        db_session.commit()
+
+        calls = {"count": 0}
+
+        async def fake_refresh(refresh_token: str) -> dict:
+            calls["count"] += 1
+            # Yield so other queued callers reach the lock while we're refreshing.
+            await asyncio.sleep(0.01)
+            return {
+                "access_token": "new_access",
+                "refresh_token": "new_refresh",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }
+
+        with patch.object(
+            manager.oauth_client, "refresh_access_token", side_effect=fake_refresh
+        ):
+            results = await asyncio.gather(
+                *[
+                    manager.get_valid_token(test_user.id, db=db_session)
+                    for _ in range(5)
+                ]
+            )
+
+        assert calls["count"] == 1  # exactly one refresh despite 5 callers
+        assert all(token == "new_access" for token in results)
+        db_session.refresh(near_expiry_token)
+        assert encryption.decrypt(near_expiry_token.refresh_token) == "new_refresh"
+
+    async def test_refresh_rejects_malformed_response(self, db_session, test_user):
+        """A refresh response missing required fields must not half-update state."""
+        manager = TokenManager()
+        encryption = get_token_encryption()
+
+        near_expiry_token = OAuthToken(
+            user_id=test_user.id,
+            access_token=encryption.encrypt("old_access"),
+            refresh_token=encryption.encrypt("old_refresh"),
+            token_type="Bearer",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            scopes=["read:sleep"],
+        )
+        db_session.add(near_expiry_token)
+        db_session.commit()
+
+        # Missing expires_in -> must raise before mutating the stored token.
+        bad_response = {"access_token": "new_access", "token_type": "Bearer"}
+
+        with patch.object(
+            manager.oauth_client,
+            "refresh_access_token",
+            new=AsyncMock(return_value=bad_response),
+        ):
+            with pytest.raises(ValueError):
+                await manager.get_valid_token(test_user.id, db=db_session)
+
+        db_session.refresh(near_expiry_token)
+        # Old token untouched.
+        assert encryption.decrypt(near_expiry_token.access_token) == "old_access"
+        assert encryption.decrypt(near_expiry_token.refresh_token) == "old_refresh"
 
     async def test_is_token_valid_true(self, db_session, test_user, test_oauth_token):
         """Test checking if token is valid."""

--- a/tests/unit/test_whoop_client.py
+++ b/tests/unit/test_whoop_client.py
@@ -117,6 +117,93 @@ class TestWhoopClientAsync:
                     await client._make_request("/test")
 
     @respx.mock
+    async def test_make_request_error_message_excludes_body(self, test_user):
+        """Non-retryable error must not leak the response body into the message."""
+        client = WhoopClient(user_id=test_user.id)
+
+        with patch.object(
+            client.token_manager,
+            "get_valid_token",
+            new=AsyncMock(return_value="test_token"),
+        ):
+            with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
+                respx.get(f"{client.base_url}/test").mock(
+                    return_value=httpx.Response(
+                        404, json={"secret_detail": "do-not-log-me"}
+                    )
+                )
+
+                with pytest.raises(WhoopAPIError) as exc_info:
+                    await client._make_request("/test")
+
+                assert "do-not-log-me" not in str(exc_info.value)
+                assert exc_info.value.status_code == 404
+
+        await client.aclose()
+
+    @respx.mock
+    async def test_make_request_retries_on_429(self, test_user):
+        """A 429 must be retried (honoring Retry-After) and then succeed."""
+        client = WhoopClient(user_id=test_user.id)
+
+        with patch.object(
+            client.token_manager,
+            "get_valid_token",
+            new=AsyncMock(return_value="test_token"),
+        ):
+            with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
+                route = respx.get(f"{client.base_url}/test")
+                route.side_effect = [
+                    httpx.Response(429, headers={"Retry-After": "0"}, json={}),
+                    httpx.Response(200, json={"ok": True}),
+                ]
+
+                result = await client._make_request("/test")
+
+                assert result == {"ok": True}
+                assert route.call_count == 2
+
+        await client.aclose()
+
+    @respx.mock
+    async def test_make_request_gives_up_after_retries(self, test_user):
+        """A persistent 503 is retried up to the attempt cap, then raised."""
+        client = WhoopClient(user_id=test_user.id)
+
+        with patch.object(
+            client.token_manager,
+            "get_valid_token",
+            new=AsyncMock(return_value="test_token"),
+        ):
+            with patch.object(client.rate_limiter, "acquire", new=AsyncMock()):
+                respx.get(f"{client.base_url}/test").mock(
+                    return_value=httpx.Response(503, headers={"Retry-After": "0"}, json={})
+                )
+
+                with pytest.raises(WhoopAPIError):
+                    await client._make_request("/test")
+
+                assert respx.calls.call_count == 3  # stop_after_attempt(3)
+
+        await client.aclose()
+
+    async def test_http_client_is_reused_and_closeable(self, test_user):
+        """The pooled AsyncClient is reused across calls and recreated after close."""
+        client = WhoopClient(user_id=test_user.id)
+
+        c1 = client._get_client()
+        c2 = client._get_client()
+        assert c1 is c2  # reused, not recreated per request
+        assert not c1.is_closed
+
+        await client.aclose()
+        assert c1.is_closed
+
+        c3 = client._get_client()
+        assert c3 is not c1  # a fresh client after close
+        await client.aclose()
+
+    @respx.mock
     async def test_get_sleep_records(self, test_user, mock_whoop_sleep_response):
         """Test fetching sleep records."""
         client = WhoopClient(user_id=test_user.id)


### PR DESCRIPTION
## Summary

Addresses correctness, data-safety, and security findings from a full-codebase review. Happy-path behavior is unchanged; this closes concurrency, data-loss, and secret-leak edges. Split into two areas below.

### CRITICAL / HIGH — auth & data correctness
- **Token refresh race (CRITICAL):** serialize OAuth refresh per user (asyncio lock + double-checked re-read) so the 5 concurrently-fanned-out services don't each spend the rotating refresh token (Whoop invalidates it, which can brick auth). Refresh is now awaited natively, removing the `ThreadPoolExecutor`/`asyncio.run` event-loop blocking. Refresh response is validated before any state mutation.
- **Empty-fetch watermark regression (HIGH):** stop writing the back-dated overlap `start` on empty / ongoing-only polls, which walked the sync watermark 7 days into the past every poll.
- **`configure_logging()` never called (HIGH):** wired up at the container entrypoint (before migrations) and in `main()`.

### HIGH — API client robustness
- **Pooled `httpx.AsyncClient`:** one reused client instead of one per request (TLS handshake per call); closed after each sync run.
- **429 / 5xx retry:** retried honoring `Retry-After` (capped), via a dedicated `WhoopRetryableError`; non-retryable statuses still fail fast.
- **Rate limiter overshoot:** `acquire()` re-checks capacity under the lock in a loop and records the slot while holding the lock, so concurrent acquirers can't exceed `max_requests`; `max_requests` guarded `>= 1`.

### HIGH — secrets in logs
- Token-endpoint errors no longer log the response body or `exc_info` (carried `client_secret` / `refresh_token` / `code`) — status code only.
- Recovery service no longer dumps a full health record at INFO (field names at DEBUG).
- API error bodies removed from logs and exception messages.

### MEDIUM — reconciliation delete-safety
- Never delete a row with a NULL natural key (e.g. recovery without `cycle_id`).
- Clamp the delete window to the actually-fetched `[start, end]` so a bounded backfill can't drop rows outside its requested range.

### MEDIUM — misc
- `check_connection()` uses `text("SELECT 1")` (was always failing under SQLAlchemy 2.0).

## Testing
`pytest` — **159 passed, 1 skipped** (pre-existing SQLite-pagination skip). New/added coverage: concurrent-refresh-happens-once, malformed-refresh rejection, NULL-key keep, fetch-start/-end window clamps, empty-fetch watermark unchanged, rate-limiter no-overshoot under concurrency + zero-floor guard, 429 retry / 503 give-up, scrubbed error message, pooled-client reuse, and `check_connection` success/failure.

## Deferred (follow-up)
- `SyncStatus` unique constraint on `(user_id, data_type)` — needs an Alembic migration + dedup of existing rows.
- `NullPool` → `QueuePool` — deliberate prod connection-pool tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)