### PR TITLE
Add SyncStatus (user_id, data_type) unique constraint with upsert

### DIFF
--- a/src/database/migrations/versions/20260605_1000_d4e5f6a7b8c9_sync_status_unique_user_datatype.py
+++ b/src/database/migrations/versions/20260605_1000_d4e5f6a7b8c9_sync_status_unique_user_datatype.py
@@ -1,0 +1,57 @@
+"""Deduplicate sync_status rows and add a (user_id, data_type) unique constraint
+
+sync_status tracks one watermark row per (user_id, data_type), but the table had
+no unique constraint — services did a select-then-insert. Two overlapping writers
+for the same user/data_type (e.g. a manual backfill racing the scheduled poll)
+could each insert, and once duplicated, scalar_one_or_none() raises
+MultipleResultsFound and wedges every later sync for that data type.
+
+This migration removes duplicates, keeping the row that has progressed furthest
+(greatest last_record_time, then last_sync_time) so we never regress a watermark,
+then adds the unique constraint that backs the on-conflict upsert.
+
+The dedup SQL is Postgres-only (ctid, row comparison); the SQLite test schema is
+built from the models via create_all, which already includes the constraint.
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-05 10:00:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd4e5f6a7b8c9'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Remove duplicate rows, then add the natural-key unique constraint."""
+    # Keep the furthest-along row per (user_id, data_type). Coalesce nullable
+    # timestamps to -infinity so a populated watermark always wins over a NULL
+    # one; ctid is the final, always-unique tiebreaker.
+    op.execute(
+        """
+        DELETE FROM sync_status a
+        USING sync_status b
+        WHERE a.user_id = b.user_id
+          AND a.data_type = b.data_type
+          AND ( COALESCE(a.last_record_time, '-infinity'),
+                COALESCE(a.last_sync_time,  '-infinity'),
+                a.ctid )
+            < ( COALESCE(b.last_record_time, '-infinity'),
+                COALESCE(b.last_sync_time,  '-infinity'),
+                b.ctid )
+        """
+    )
+
+    op.create_unique_constraint(
+        'uq_sync_user_datatype', 'sync_status', ['user_id', 'data_type']
+    )
+
+
+def downgrade() -> None:
+    """Drop the unique constraint (duplicate rows are not restored)."""
+    op.drop_constraint('uq_sync_user_datatype', 'sync_status', type_='unique')

--- a/src/models/db_models.py
+++ b/src/models/db_models.py
@@ -1,7 +1,5 @@
 """SQLAlchemy database models for Whoopster application."""
 
-from datetime import datetime
-from typing import Optional, List, Any
 import uuid
 import json
 
@@ -468,6 +466,8 @@ class SyncStatus(Base):
         )
 
     __table_args__ = (
-        # Unique constraint: one sync status per user per data type
-        {"schema": None},
+        # One sync status row per user per data type. Backs the on-conflict
+        # upsert in upsert_sync_status() and prevents duplicate rows (which
+        # would make scalar_one_or_none() raise MultipleResultsFound).
+        UniqueConstraint("user_id", "data_type", name="uq_sync_user_datatype"),
     )

--- a/src/services/body_measurement_service.py
+++ b/src/services/body_measurement_service.py
@@ -14,8 +14,9 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from src.api.whoop_client import WhoopClient, WhoopAPIError
-from src.models.db_models import BodyMeasurement, SyncStatus
+from src.models.db_models import BodyMeasurement
 from src.database.session import get_db_context
+from src.services.sync_status import upsert_sync_status
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -193,45 +194,23 @@ class BodyMeasurementService:
     ) -> None:
         """Update sync status row for the body_measurement data type."""
         with get_db_context() as db:
-            stmt = (
-                select(SyncStatus)
-                .where(SyncStatus.user_id == self.user_id)
-                .where(SyncStatus.data_type == "body_measurement")
-            )
-            sync_status = db.execute(stmt).scalar_one_or_none()
-
-            if sync_status:
-                sync_status.status = status
-                sync_status.last_sync_time = last_sync_time or datetime.now(timezone.utc)
-
-                if records_fetched is not None:
-                    sync_status.records_fetched = records_fetched
-                if last_record_time:
-                    sync_status.last_record_time = last_record_time
-                if error_message:
-                    sync_status.error_message = error_message
-                else:
-                    sync_status.error_message = None
-
-                sync_status.updated_at = datetime.now(timezone.utc)
-            else:
-                sync_status = SyncStatus(
-                    user_id=self.user_id,
-                    data_type="body_measurement",
-                    status=status,
-                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
-                    last_record_time=last_record_time,
-                    records_fetched=records_fetched,
-                    error_message=error_message,
-                )
-                db.add(sync_status)
-
-            logger.debug(
-                "Updated sync status",
+            upsert_sync_status(
+                db,
+                user_id=self.user_id,
                 data_type="body_measurement",
                 status=status,
                 records_fetched=records_fetched,
+                last_sync_time=last_sync_time,
+                last_record_time=last_record_time,
+                error_message=error_message,
             )
+
+        logger.debug(
+            "Updated sync status",
+            data_type="body_measurement",
+            status=status,
+            records_fetched=records_fetched,
+        )
 
     async def get_body_measurement_statistics(self) -> Dict[str, Any]:
         """

--- a/src/services/cycle_service.py
+++ b/src/services/cycle_service.py
@@ -14,6 +14,7 @@ from src.api.whoop_client import WhoopClient
 from src.models.db_models import CycleRecord, SyncStatus
 from src.database.session import get_db_context
 from src.services.reconcile import windowed_start, reconcile_deletes
+from src.services.sync_status import upsert_sync_status
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -277,51 +278,23 @@ class CycleService:
             error_message: Error message if failed
         """
         with get_db_context() as db:
-            # Check if sync status exists
-            stmt = (
-                select(SyncStatus)
-                .where(SyncStatus.user_id == self.user_id)
-                .where(SyncStatus.data_type == "cycle")
-            )
-            sync_status = db.execute(stmt).scalar_one_or_none()
-
-            if sync_status:
-                # Update existing
-                sync_status.status = status
-                sync_status.last_sync_time = last_sync_time or datetime.now(
-                    timezone.utc
-                )
-
-                if records_fetched is not None:
-                    sync_status.records_fetched = records_fetched
-                if last_record_time:
-                    sync_status.last_record_time = last_record_time
-                if error_message:
-                    sync_status.error_message = error_message
-                else:
-                    sync_status.error_message = None  # Clear previous errors
-
-                sync_status.updated_at = datetime.now(timezone.utc)
-
-            else:
-                # Create new
-                sync_status = SyncStatus(
-                    user_id=self.user_id,
-                    data_type="cycle",
-                    status=status,
-                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
-                    last_record_time=last_record_time,
-                    records_fetched=records_fetched,
-                    error_message=error_message,
-                )
-                db.add(sync_status)
-
-            logger.debug(
-                "Updated sync status",
+            upsert_sync_status(
+                db,
+                user_id=self.user_id,
                 data_type="cycle",
                 status=status,
                 records_fetched=records_fetched,
+                last_sync_time=last_sync_time,
+                last_record_time=last_record_time,
+                error_message=error_message,
             )
+
+        logger.debug(
+            "Updated sync status",
+            data_type="cycle",
+            status=status,
+            records_fetched=records_fetched,
+        )
 
     async def get_cycle_statistics(self) -> Dict[str, Any]:
         """

--- a/src/services/recovery_service.py
+++ b/src/services/recovery_service.py
@@ -15,6 +15,7 @@ from src.api.whoop_client import WhoopClient
 from src.models.db_models import RecoveryRecord, SyncStatus
 from src.database.session import get_db_context
 from src.services.reconcile import windowed_start, reconcile_deletes
+from src.services.sync_status import upsert_sync_status
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -277,51 +278,23 @@ class RecoveryService:
             error_message: Error message if failed
         """
         with get_db_context() as db:
-            # Check if sync status exists
-            stmt = (
-                select(SyncStatus)
-                .where(SyncStatus.user_id == self.user_id)
-                .where(SyncStatus.data_type == "recovery")
-            )
-            sync_status = db.execute(stmt).scalar_one_or_none()
-
-            if sync_status:
-                # Update existing
-                sync_status.status = status
-                sync_status.last_sync_time = last_sync_time or datetime.now(
-                    timezone.utc
-                )
-
-                if records_fetched is not None:
-                    sync_status.records_fetched = records_fetched
-                if last_record_time:
-                    sync_status.last_record_time = last_record_time
-                if error_message:
-                    sync_status.error_message = error_message
-                else:
-                    sync_status.error_message = None  # Clear previous errors
-
-                sync_status.updated_at = datetime.now(timezone.utc)
-
-            else:
-                # Create new
-                sync_status = SyncStatus(
-                    user_id=self.user_id,
-                    data_type="recovery",
-                    status=status,
-                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
-                    last_record_time=last_record_time,
-                    records_fetched=records_fetched,
-                    error_message=error_message,
-                )
-                db.add(sync_status)
-
-            logger.debug(
-                "Updated sync status",
+            upsert_sync_status(
+                db,
+                user_id=self.user_id,
                 data_type="recovery",
                 status=status,
                 records_fetched=records_fetched,
+                last_sync_time=last_sync_time,
+                last_record_time=last_record_time,
+                error_message=error_message,
             )
+
+        logger.debug(
+            "Updated sync status",
+            data_type="recovery",
+            status=status,
+            records_fetched=records_fetched,
+        )
 
     async def get_recovery_statistics(self) -> Dict[str, Any]:
         """

--- a/src/services/sleep_service.py
+++ b/src/services/sleep_service.py
@@ -15,6 +15,7 @@ from src.api.whoop_client import WhoopClient
 from src.models.db_models import SleepRecord, SyncStatus
 from src.database.session import get_db_context
 from src.services.reconcile import windowed_start, reconcile_deletes
+from src.services.sync_status import upsert_sync_status
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -270,51 +271,23 @@ class SleepService:
             error_message: Error message if failed
         """
         with get_db_context() as db:
-            # Check if sync status exists
-            stmt = (
-                select(SyncStatus)
-                .where(SyncStatus.user_id == self.user_id)
-                .where(SyncStatus.data_type == "sleep")
-            )
-            sync_status = db.execute(stmt).scalar_one_or_none()
-
-            if sync_status:
-                # Update existing
-                sync_status.status = status
-                sync_status.last_sync_time = last_sync_time or datetime.now(
-                    timezone.utc
-                )
-
-                if records_fetched is not None:
-                    sync_status.records_fetched = records_fetched
-                if last_record_time:
-                    sync_status.last_record_time = last_record_time
-                if error_message:
-                    sync_status.error_message = error_message
-                else:
-                    sync_status.error_message = None  # Clear previous errors
-
-                sync_status.updated_at = datetime.now(timezone.utc)
-
-            else:
-                # Create new
-                sync_status = SyncStatus(
-                    user_id=self.user_id,
-                    data_type="sleep",
-                    status=status,
-                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
-                    last_record_time=last_record_time,
-                    records_fetched=records_fetched,
-                    error_message=error_message,
-                )
-                db.add(sync_status)
-
-            logger.debug(
-                "Updated sync status",
+            upsert_sync_status(
+                db,
+                user_id=self.user_id,
                 data_type="sleep",
                 status=status,
                 records_fetched=records_fetched,
+                last_sync_time=last_sync_time,
+                last_record_time=last_record_time,
+                error_message=error_message,
             )
+
+        logger.debug(
+            "Updated sync status",
+            data_type="sleep",
+            status=status,
+            records_fetched=records_fetched,
+        )
 
     async def get_sleep_statistics(self) -> Dict[str, Any]:
         """

--- a/src/services/sync_status.py
+++ b/src/services/sync_status.py
@@ -1,0 +1,66 @@
+"""Shared upsert for the per-(user, data_type) sync watermark row.
+
+All data services record their progress in a single ``sync_status`` row keyed
+by ``(user_id, data_type)``. Writing it via ``on_conflict_do_update`` (rather
+than select-then-insert) makes the write atomic, so two overlapping syncs for
+the same user/data_type can't both insert and create duplicate rows.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from src.models.db_models import SyncStatus
+
+
+def upsert_sync_status(
+    db: Session,
+    *,
+    user_id: int,
+    data_type: str,
+    status: str,
+    records_fetched: Optional[int] = None,
+    last_sync_time: Optional[datetime] = None,
+    last_record_time: Optional[datetime] = None,
+    error_message: Optional[str] = None,
+) -> None:
+    """Insert or update the sync_status row for one (user_id, data_type).
+
+    ``records_fetched`` and ``last_record_time`` are only written when provided;
+    passing ``None`` leaves the existing value untouched (so an error path or an
+    empty fetch never clobbers the watermark). ``error_message`` is always set —
+    to its value on failure, or cleared to ``None`` on success.
+    """
+    now = datetime.now(timezone.utc)
+    last_sync_time = last_sync_time or now
+
+    insert_values = {
+        "user_id": user_id,
+        "data_type": data_type,
+        "status": status,
+        "last_sync_time": last_sync_time,
+        "last_record_time": last_record_time,
+        "records_fetched": records_fetched,
+        "error_message": error_message,
+        "updated_at": now,
+    }
+
+    update_set = {
+        "status": status,
+        "last_sync_time": last_sync_time,
+        "error_message": error_message,
+        "updated_at": now,
+    }
+    # Preserve existing values when the caller didn't supply a new one.
+    if records_fetched is not None:
+        update_set["records_fetched"] = records_fetched
+    if last_record_time is not None:
+        update_set["last_record_time"] = last_record_time
+
+    stmt = insert(SyncStatus).values(**insert_values).on_conflict_do_update(
+        index_elements=["user_id", "data_type"],
+        set_=update_set,
+    )
+    db.execute(stmt)

--- a/src/services/workout_service.py
+++ b/src/services/workout_service.py
@@ -15,6 +15,7 @@ from src.api.whoop_client import WhoopClient
 from src.models.db_models import WorkoutRecord, SyncStatus
 from src.database.session import get_db_context
 from src.services.reconcile import windowed_start, reconcile_deletes
+from src.services.sync_status import upsert_sync_status
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -261,51 +262,23 @@ class WorkoutService:
             error_message: Error message if failed
         """
         with get_db_context() as db:
-            # Check if sync status exists
-            stmt = (
-                select(SyncStatus)
-                .where(SyncStatus.user_id == self.user_id)
-                .where(SyncStatus.data_type == "workout")
-            )
-            sync_status = db.execute(stmt).scalar_one_or_none()
-
-            if sync_status:
-                # Update existing
-                sync_status.status = status
-                sync_status.last_sync_time = last_sync_time or datetime.now(
-                    timezone.utc
-                )
-
-                if records_fetched is not None:
-                    sync_status.records_fetched = records_fetched
-                if last_record_time:
-                    sync_status.last_record_time = last_record_time
-                if error_message:
-                    sync_status.error_message = error_message
-                else:
-                    sync_status.error_message = None  # Clear previous errors
-
-                sync_status.updated_at = datetime.now(timezone.utc)
-
-            else:
-                # Create new
-                sync_status = SyncStatus(
-                    user_id=self.user_id,
-                    data_type="workout",
-                    status=status,
-                    last_sync_time=last_sync_time or datetime.now(timezone.utc),
-                    last_record_time=last_record_time,
-                    records_fetched=records_fetched,
-                    error_message=error_message,
-                )
-                db.add(sync_status)
-
-            logger.debug(
-                "Updated sync status",
+            upsert_sync_status(
+                db,
+                user_id=self.user_id,
                 data_type="workout",
                 status=status,
                 records_fetched=records_fetched,
+                last_sync_time=last_sync_time,
+                last_record_time=last_record_time,
+                error_message=error_message,
             )
+
+        logger.debug(
+            "Updated sync status",
+            data_type="workout",
+            status=status,
+            records_fetched=records_fetched,
+        )
 
     async def get_workout_statistics(self) -> Dict[str, Any]:
         """

--- a/tests/unit/test_sync_status.py
+++ b/tests/unit/test_sync_status.py
@@ -1,0 +1,125 @@
+"""Tests for the shared sync_status upsert + the (user_id, data_type) constraint."""
+
+import pytest
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import IntegrityError
+
+from src.models.db_models import SyncStatus
+from src.services.sync_status import upsert_sync_status
+
+
+def _utc(dt):
+    """Normalize a possibly-naive stored datetime to tz-aware UTC for comparison."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+@pytest.mark.unit
+class TestSyncStatusConstraint:
+    def test_duplicate_user_datatype_rejected(self, db_session, test_user):
+        db_session.add(
+            SyncStatus(user_id=test_user.id, data_type="sleep", status="success")
+        )
+        db_session.commit()
+
+        db_session.add(
+            SyncStatus(user_id=test_user.id, data_type="sleep", status="success")
+        )
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()
+
+
+@pytest.mark.unit
+class TestUpsertSyncStatus:
+    def test_inserts_then_updates_in_place(self, db_session, test_user):
+        wm1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        wm2 = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="success",
+            records_fetched=3,
+            last_record_time=wm1,
+        )
+        db_session.commit()
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="success",
+            records_fetched=5,
+            last_record_time=wm2,
+        )
+        db_session.commit()
+
+        rows = (
+            db_session.query(SyncStatus)
+            .filter_by(user_id=test_user.id, data_type="sleep")
+            .all()
+        )
+        assert len(rows) == 1  # upserted, not duplicated
+        assert rows[0].records_fetched == 5
+        assert _utc(rows[0].last_record_time) == wm2
+
+    def test_preserves_watermark_and_count_when_none(self, db_session, test_user):
+        wm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="success",
+            records_fetched=3,
+            last_record_time=wm,
+        )
+        db_session.commit()
+
+        # Error-path style call: no watermark, no count supplied.
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="error",
+            error_message="boom",
+            last_record_time=None,
+            records_fetched=None,
+        )
+        db_session.commit()
+
+        row = (
+            db_session.query(SyncStatus)
+            .filter_by(user_id=test_user.id, data_type="sleep")
+            .one()
+        )
+        assert row.status == "error"
+        assert row.error_message == "boom"
+        assert _utc(row.last_record_time) == wm  # preserved, not clobbered
+        assert row.records_fetched == 3  # preserved
+
+    def test_clears_error_on_success(self, db_session, test_user):
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="error",
+            error_message="boom",
+        )
+        db_session.commit()
+
+        upsert_sync_status(
+            db_session,
+            user_id=test_user.id,
+            data_type="sleep",
+            status="success",
+        )
+        db_session.commit()
+
+        row = (
+            db_session.query(SyncStatus)
+            .filter_by(user_id=test_user.id, data_type="sleep")
+            .one()
+        )
+        assert row.status == "success"
+        assert row.error_message is None


### PR DESCRIPTION
## Summary

Follow-up to #95. Closes the remaining MEDIUM finding from the code review: `sync_status` had no uniqueness on `(user_id, data_type)`, and services did a select-then-insert. Two overlapping writers for the same user/data_type (e.g. a manual backfill racing the scheduled poll) could each insert; once duplicated, `scalar_one_or_none()` raises `MultipleResultsFound` and wedges every later sync for that data type.

## Changes
- **Model:** add `UniqueConstraint(user_id, data_type, name="uq_sync_user_datatype")` (replacing a no-op `__table_args__`).
- **Migration** (`d4e5f6a7b8c9`, revises head `c3d4e5f6a7b8`): deduplicate existing rows **keeping the furthest-along row** (greatest `last_record_time`, then `last_sync_time`, `ctid` tiebreak) so no watermark regresses, then add the constraint. Postgres-only data SQL, mirroring the recovery/cycle dedup migration; the SQLite test schema gets the constraint via `create_all`.
- **Upsert:** new `upsert_sync_status()` helper using `on_conflict_do_update`; all five services delegate to it, removing ~25 duplicated select-then-insert lines each. `records_fetched` / `last_record_time` are only written when provided, so error paths and empty fetches never clobber the watermark.

## Why the dedup keeps "furthest-along" rather than "newest"
Unlike the recovery/cycle dedup (identical duplicate data), `sync_status` duplicates can hold *different* watermarks — keeping the wrong one would reset `last_record_time` backward and trigger a needless large re-fetch. So the tiebreak is by watermark, not `created_at`.

## Testing
`pytest` — **163 passed, 1 skipped** (pre-existing). New `tests/unit/test_sync_status.py`: constraint rejects duplicates; upsert inserts-then-updates in place; `None` watermark/count preserved; `error_message` cleared on success.

## Note
This was originally the second commit on the #95 branch; #95 squash-merged with only the first commit, so this is split out as its own PR on top of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)