### PR TITLE
Use a bounded QueuePool with pre-ping instead of NullPool

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -646,12 +646,23 @@ For multiple users or higher sync frequency:
 
 **Database Connection Pooling:**
 
+The app uses a bounded SQLAlchemy `QueuePool` with `pool_pre_ping` enabled. The
+defaults suit a single/low-user deployment:
+
 ```python
-# src/config.py
-class Settings(BaseSettings):
-    # ...
-    db_pool_size: int = 20
-    db_max_overflow: int = 40
+# src/config.py defaults
+db_pool_size: int = 5
+db_max_overflow: int = 10
+db_pool_recycle_seconds: int = 1800
+```
+
+For multiple users or higher sync frequency, raise the pool size/overflow via
+environment variables (each app instance keeps its own pool — there is no
+external PgBouncer):
+
+```bash
+DB_POOL_SIZE=20
+DB_MAX_OVERFLOW=40
 ```
 
 **Multiple App Instances:**

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,5 @@
 """Application configuration using Pydantic Settings."""
 
-import os
 import sys
 from pathlib import Path
 from urllib.parse import quote_plus
@@ -68,6 +67,15 @@ class Settings(BaseSettings):
     # Rate Limiting
     max_requests_per_minute: int = 60
 
+    # Database connection pool (QueuePool). Each app instance keeps its own pool
+    # (no external PgBouncer). pool_pre_ping is always on so a DB restart or idle
+    # timeout is recovered transparently instead of erroring mid-query. Defaults
+    # suit a single/low-user deployment; bump for horizontal scaling (see
+    # docs/DEPLOYMENT.md).
+    db_pool_size: int = 5
+    db_max_overflow: int = 10
+    db_pool_recycle_seconds: int = 1800
+
     # Security Configuration
     token_encryption_key: str  # Required: Fernet encryption key for OAuth tokens
 
@@ -129,7 +137,7 @@ def _initialize_settings() -> Settings:
                 error_lines.append(f"  - {item['field']}: {item['error']}")
 
         error_lines.extend([
-            f"\nPlease set these environment variables in your .env file or Docker environment.",
+            "\nPlease set these environment variables in your .env file or Docker environment.",
             f"For local development, create .env at: {ENV_FILE}",
             f"You can use .env.example as a template: {PROJECT_ROOT / '.env.example'}",
             "",

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -5,18 +5,26 @@ from typing import Generator
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, Session
-from sqlalchemy.pool import NullPool
+from sqlalchemy.pool import QueuePool
 
 from src.config import settings
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# Create SQLAlchemy engine
-# For production, consider using connection pooling instead of NullPool
+# Create SQLAlchemy engine with a bounded connection pool. The app fans out
+# several concurrent sessions per sync; a pool caps concurrent connections
+# (so a burst can't exhaust Postgres max_connections) and reuses warm
+# connections instead of re-handshaking TLS/auth every session. pool_pre_ping
+# validates a connection before use, so a DB restart / idle timeout is
+# recovered transparently. No external pooler (PgBouncer) is in front.
 engine = create_engine(
     settings.database_url,
-    poolclass=NullPool,  # No connection pooling for simplicity
+    poolclass=QueuePool,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+    pool_recycle=settings.db_pool_recycle_seconds,
+    pool_pre_ping=True,
     echo=False,  # Set to True for SQL query logging
     future=True,  # Use SQLAlchemy 2.0 style
 )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,8 +2,10 @@
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.pool import QueuePool
 
 import src.database.session as session_module
+from src.config import settings
 
 
 @pytest.mark.unit
@@ -27,3 +29,19 @@ def test_check_connection_failure_returns_false(monkeypatch):
     monkeypatch.setattr(session_module, "engine", bad_engine)
 
     assert session_module.check_connection() is False
+
+
+@pytest.mark.unit
+def test_engine_uses_bounded_pool_with_pre_ping():
+    """The production engine must use a bounded QueuePool with pre-ping on.
+
+    Inspecting the pool does not open a connection, so this is safe without a
+    live database.
+    """
+    pool = session_module.engine.pool
+
+    assert isinstance(pool, QueuePool)
+    assert pool._pre_ping is True
+    assert pool.size() == settings.db_pool_size
+    assert pool._max_overflow == settings.db_max_overflow
+    assert pool._recycle == settings.db_pool_recycle_seconds


### PR DESCRIPTION
## Summary

Final item from the code-review notes. Replaces `NullPool` with a bounded `QueuePool` + `pool_pre_ping`. Confirmed with the maintainer that **no external pooler (PgBouncer) fronts Postgres** — each app manages its own connections — so a client-side pool is the correct layer.

## Why
`NullPool` opened a fresh TCP + TLS + auth + backend-process connection for **every** session, and had **no connection ceiling**. The scheduler fans out 5 services concurrently per sync, each opening several short sessions, so a burst (a manual backfill overlapping the scheduled run, or more users) could march toward Postgres `max_connections`. A bounded pool caps concurrency (queues instead of exhausting the server) and reuses warm connections.

## Changes
- Engine now uses `QueuePool` with `pool_pre_ping=True` (transparently discards a connection killed by a DB restart / idle timeout instead of erroring mid-query) and `pool_recycle`.
- Pool sizing is configurable: `db_pool_size=5`, `db_max_overflow=10`, `db_pool_recycle_seconds=1800` — modest defaults for a single/low-user deployment, overridable via env for horizontal scaling.
- `docs/DEPLOYMENT.md` updated to match the implemented defaults (it previously documented `db_pool_size=20` settings that didn't exist in code) and to give env-based scale-up guidance.

## Testing
`pytest` — **160 passed, 1 skipped** (pre-existing). New test asserts the engine uses a bounded `QueuePool` with pre-ping, introspecting the pool **without opening a connection** (so it's safe in CI with no live DB).

## Notes
- Independent of #96 (SyncStatus constraint) — different files, no conflict; either can merge first.
- `pool_pre_ping` resilience is something `NullPool` didn't need (it never reused a connection); it becomes relevant precisely because we now pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)