### PR TITLE
feat: bronze-only range backfill, serialized with the poller

### DIFF
--- a/docs/BRONZE.md
+++ b/docs/BRONZE.md
@@ -101,9 +101,47 @@ Each payload is written with a sidecar carrying provenance the raw bytes don't:
 - Bronze is **append-only and immutable** — nothing is ever overwritten,
   deleted, or compacted here. Retention/cleanup is a later concern.
 
+## Backfilling gaps
+
+To "true up" missing bronze data between two dates, run the bronze backfill
+**inside the already-running container** (so it inherits the env vars and bronze
+volume mount):
+
+```bash
+docker exec <container> python -m scripts.backfill_data --start 2025-12-17
+docker exec <container> python -m scripts.backfill_data --start 2025-12-17 --end 2026-01-15
+docker exec <container> python -m scripts.backfill_data --days 30 --types sleep recovery
+```
+
+It fetches the range from the Whoop API so each raw page is captured to bronze;
+**nothing is written to the database**. Only range-based collections can be
+backfilled (`sleep`, `recovery`, `workout`, `cycle`); `profile` and
+`body_measurement` are current-snapshot endpoints with no date range. If
+`BRONZE_ROOT` is unset the command exits with an error (there would be nothing
+to write).
+
+### Staying under the API rate limit
+
+The poller and a backfill run as **separate processes** in the same container,
+each with its own in-memory rate limiter — so they must never call the Whoop API
+at the same time. They are serialized by an advisory file lock
+(`src/utils/sync_lock.py`) at `SYNC_LOCK_PATH` (default `/tmp/whoop_sync.lock`):
+
+- the backfill takes the lock (waiting up to `SYNC_LOCK_TIMEOUT_SECONDS` for any
+  in-flight poll to finish), then holds it for the whole run;
+- the poller takes the lock non-blocking and **skips that cycle** if a backfill
+  holds it, catching up on the next interval.
+
+Because only one process ever hits the API at a time, the per-process limiter is
+enough to stay under the limit. The lock is released automatically by the kernel
+if a process exits or crashes, so there is no stale lock to clean up.
+
 ## Implementation
 
 - `src/bronze/capture.py` — the writer (`capture_bronze`, atomic writes,
   sidecar, naming). Self-contained and source-agnostic.
 - `src/api/whoop_client.py` — captures at the single request chokepoint
   (`_make_request`), threading a `collection` label from each fetch method.
+- `scripts/backfill_data.py` — bronze-only, lock-serialized range backfill.
+- `src/utils/sync_lock.py` — the advisory file lock that serializes the poller
+  and backfill.

--- a/scripts/backfill_data.py
+++ b/scripts/backfill_data.py
@@ -1,307 +1,231 @@
 #!/usr/bin/env python3
-"""
-Backfill historical Whoop data.
+"""Backfill raw Whoop data into the bronze layer for a date range.
 
-This script allows you to fetch historical data from Whoop by specifying
-a date range. Useful for:
-- Initial setup to fetch all historical data
-- Filling gaps in data due to sync failures
-- Re-syncing data from a specific time period
+Use this to "true up" gaps in bronze between two dates. It fetches the requested
+range from the Whoop API; the raw responses are captured to the bronze layer at
+the HTTP-client level. NOTHING is written to the database -- this is a
+bronze-only tool.
 
-Usage:
-    # Backfill all data from last 30 days
-    python -m scripts.backfill_data --days 30
+It is safe to run on a server whose container is already running the regular
+poller: a shared advisory file lock (src/utils/sync_lock.py) ensures the poller
+and this backfill never call the API at the same time, so the per-process rate
+limiter keeps you under the Whoop API limit. This backfill waits for any
+in-flight poll to finish, then holds the lock (the poller skips its cycle) until
+it completes.
 
-    # Backfill specific date range
-    python -m scripts.backfill_data --start 2024-01-01 --end 2024-12-31
+Bronze capture must be enabled (BRONZE_ROOT set, with a persistent volume
+mounted at that path) or this tool has nothing to write and exits with an error.
 
-    # Backfill only specific data types
-    python -m scripts.backfill_data --days 90 --types sleep recovery
+Usage (typically via `docker exec` into the already-running container, so the
+env vars and bronze volume are inherited):
 
-    # Backfill all available historical data (can take a while!)
-    python -m scripts.backfill_data --all
+    docker exec <container> python -m scripts.backfill_data --start 2025-12-17
+    docker exec <container> python -m scripts.backfill_data --start 2025-12-17 --end 2026-01-15
+    docker exec <container> python -m scripts.backfill_data --days 30
+    docker exec <container> python -m scripts.backfill_data --start 2025-12-17 --types sleep recovery
 
-Examples:
-    # Get last 6 months of data
-    python -m scripts.backfill_data --days 180
-
-    # Get data from specific month
-    python -m scripts.backfill_data --start 2024-06-01 --end 2024-06-30
-
-    # Get only sleep and workout data from last year
-    python -m scripts.backfill_data --days 365 --types sleep workout
+Only range-based data types can be backfilled (sleep, recovery, workout, cycle);
+profile and body measurement are current-snapshot endpoints with no date range.
 """
 
-import asyncio
 import argparse
+import asyncio
 import sys
-from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Optional, List
+from pathlib import Path
+from typing import Dict, List, Optional
 
 # Add project root to Python path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.services.data_collector import DataCollector
+from src.api.whoop_client import WhoopClient
+from src.auth.token_manager import TokenManager
+from src.bronze import is_bronze_enabled
 from src.utils.logging_config import get_logger
+from src.utils.sync_lock import SyncLockTimeout, sync_lock
 
 logger = get_logger(__name__)
+
+# Range-based collections only. Current-snapshot endpoints (profile, body
+# measurement) have no date range and so cannot be "backfilled".
+RANGE_DATA_TYPES = ["sleep", "recovery", "workout", "cycle"]
+
+# Maps a data type to the WhoopClient method that fetches (and, via the client,
+# bronze-captures) its records for a date range.
+_FETCHERS = {
+    "sleep": "get_sleep_records",
+    "recovery": "get_recovery_records",
+    "workout": "get_workout_records",
+    "cycle": "get_cycle_records",
+}
 
 
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="Backfill historical Whoop data",
+        description="Backfill raw Whoop data into the bronze layer for a date range",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
 
-    # Date range options
     date_group = parser.add_mutually_exclusive_group(required=True)
     date_group.add_argument(
         "--days",
         type=int,
-        help="Number of days to backfill from today (e.g., 30, 90, 365)",
-    )
-    date_group.add_argument(
-        "--all",
-        action="store_true",
-        help="Backfill all available historical data (no start date limit)",
+        help="Backfill from N days ago through now (e.g., 30, 90)",
     )
     date_group.add_argument(
         "--start",
         type=str,
-        help="Start date in YYYY-MM-DD format (requires --end)",
+        help="Start date in YYYY-MM-DD format (end defaults to now)",
     )
 
     parser.add_argument(
         "--end",
         type=str,
-        help="End date in YYYY-MM-DD format (optional, defaults to today)",
+        help="End date in YYYY-MM-DD format (optional, defaults to now)",
     )
-
     parser.add_argument(
         "--types",
         nargs="+",
-        choices=["sleep", "recovery", "workout", "cycle"],
-        help="Specific data types to sync (default: all types)",
+        choices=RANGE_DATA_TYPES,
+        help=f"Data types to backfill (default: {', '.join(RANGE_DATA_TYPES)})",
     )
-
     parser.add_argument(
         "--user-id",
         type=int,
         default=1,
-        help="User ID to sync data for (default: 1)",
+        help="User ID to backfill data for (default: 1)",
     )
 
     return parser.parse_args()
 
 
 def parse_date(date_str: str) -> datetime:
-    """
-    Parse date string to datetime object.
-
-    Args:
-        date_str: Date in YYYY-MM-DD format
-
-    Returns:
-        Datetime object in UTC timezone
-
-    Raises:
-        ValueError: If date format is invalid
-    """
+    """Parse a YYYY-MM-DD string to a UTC datetime."""
     try:
-        dt = datetime.strptime(date_str, "%Y-%m-%d")
-        return dt.replace(tzinfo=timezone.utc)
+        return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
     except ValueError as e:
         raise ValueError(
             f"Invalid date format: {date_str}. Use YYYY-MM-DD format."
         ) from e
 
 
-async def backfill_data(
+async def fetch_range_to_bronze(
+    client: WhoopClient,
+    start: datetime,
+    end: datetime,
+    data_types: List[str],
+) -> Dict[str, int]:
+    """Fetch each data type over [start, end]; raw pages are captured to bronze.
+
+    Records are fetched only to drive capture (which happens at the HTTP-client
+    level) and to count them; nothing is written to the database.
+
+    Returns:
+        Mapping of data type -> number of records fetched.
+    """
+    totals: Dict[str, int] = {}
+    for data_type in data_types:
+        fetch = getattr(client, _FETCHERS[data_type])
+        records = await fetch(start=start, end=end)
+        totals[data_type] = len(records)
+        logger.info(
+            "Backfilled type to bronze",
+            data_type=data_type,
+            count=len(records),
+        )
+    return totals
+
+
+async def backfill_bronze(
     user_id: int,
-    start: Optional[datetime],
-    end: Optional[datetime],
-    data_types: Optional[List[str]],
-) -> None:
-    """
-    Backfill historical data for a user.
+    start: datetime,
+    end: datetime,
+    data_types: List[str],
+) -> int:
+    """Run the bronze backfill. Returns a process exit code (0 = success)."""
+    # Fail fast if the user has no usable token, before holding the lock.
+    token_manager = TokenManager()
+    if not await token_manager.get_valid_token(user_id):
+        print(f"\n❌ ERROR: user {user_id} has no valid Whoop OAuth token.")
+        print("   Authorize first (scripts/init_oauth.py), then retry.\n")
+        return 1
 
-    Args:
-        user_id: Database user ID
-        start: Start date for backfill (None = no limit)
-        end: End date for backfill (None = today)
-        data_types: List of data types to sync (None = all)
-    """
-    # Check if user exists and has OAuth tokens
-    from src.database.session import get_db_context
-    from src.models.db_models import User, OAuthToken
-    from sqlalchemy import select
-
-    with get_db_context() as db:
-        # Check if user exists
-        user = db.execute(select(User).where(User.id == user_id)).scalar_one_or_none()
-
-        if user is None:
-            print("\n" + "=" * 70)
-            print("❌ ERROR: User Not Found")
-            print("=" * 70)
-            print(f"User ID {user_id} does not exist in the database.")
-            print("\nYou must run OAuth setup first to create a user and authorize Whoop access:")
-            print("\n  docker-compose exec app python scripts/init_oauth.py")
-            print("\nThis will:")
-            print("  1. Create a user record in the database")
-            print("  2. Open your browser to authorize Whoop access")
-            print("  3. Store OAuth tokens securely")
-            print("\nAfter OAuth setup completes, you can run the backfill script.")
-            print("=" * 70 + "\n")
-            return
-
-        # Check if OAuth tokens exist
-        oauth_token = db.execute(
-            select(OAuthToken).where(OAuthToken.user_id == user_id)
-        ).scalar_one_or_none()
-
-        if oauth_token is None:
-            print("\n" + "=" * 70)
-            print("❌ ERROR: No OAuth Tokens Found")
-            print("=" * 70)
-            print(f"User ID {user_id} exists but has no OAuth tokens.")
-            print("\nYou must authorize Whoop access first:")
-            print("\n  docker-compose exec app python scripts/init_oauth.py")
-            print("\nThis will open your browser to authorize access to your Whoop data.")
-            print("=" * 70 + "\n")
-            return
-
-    # Default end date to now if not specified
-    if end is None:
-        end = datetime.now(timezone.utc)
-
-    logger.info(
-        "Starting historical data backfill",
-        user_id=user_id,
-        start=start.isoformat() if start else "No limit (all history)",
-        end=end.isoformat(),
-        data_types=data_types or "all",
-    )
+    client = WhoopClient(user_id=user_id, token_manager=token_manager)
+    try:
+        totals = await fetch_range_to_bronze(client, start, end, data_types)
+    finally:
+        await client.aclose()
 
     print("\n" + "=" * 70)
-    print("HISTORICAL DATA BACKFILL")
+    print("BRONZE BACKFILL COMPLETE")
     print("=" * 70)
-    print(f"User ID: {user_id}")
-    print(f"Start Date: {start.strftime('%Y-%m-%d') if start else 'All available history'}")
-    print(f"End Date: {end.strftime('%Y-%m-%d')}")
-    print(f"Data Types: {', '.join(data_types) if data_types else 'All (sleep, recovery, workout, cycle)'}")
-    print("=" * 70)
-
-    if not start:
-        print("\n⚠️  WARNING: Fetching ALL historical data may take a long time!")
-        print("    Whoop stores your complete history since you started using the device.")
-        response = input("\nContinue? (yes/no): ")
-        if response.lower() not in ["yes", "y"]:
-            print("Backfill cancelled.")
-            return
-
-    print("\n🔄 Starting backfill...\n")
-
-    try:
-        # Initialize data collector
-        collector = DataCollector(user_id=user_id)
-
-        # Run backfill
-        results = await collector.sync_all_data(
-            start=start,
-            end=end,
-            data_types=data_types,
-        )
-
-        # Display results
-        print("\n" + "=" * 70)
-        print("BACKFILL COMPLETE")
-        print("=" * 70)
-        print(f"Total Records Synced: {results['total_records']}")
-        print(f"Total Errors: {results['total_errors']}")
-        print("\nResults by Data Type:")
-
-        for data_type, result in results["results"].items():
-            status_icon = "✅" if result["status"] == "success" else "❌"
-            print(f"  {status_icon} {data_type.capitalize()}: {result.get('records_synced', 0)} records")
-            if result["status"] == "error":
-                print(f"     Error: {result.get('error', 'Unknown error')}")
-
-        print("=" * 70 + "\n")
-
-        if results["total_errors"] > 0:
-            logger.warning(
-                "Backfill completed with errors",
-                total_records=results["total_records"],
-                total_errors=results["total_errors"],
-            )
-        else:
-            logger.info(
-                "Backfill completed successfully",
-                total_records=results["total_records"],
-            )
-
-    except Exception as e:
-        logger.error(
-            "Backfill failed",
-            error=str(e),
-            exc_info=True,
-        )
-        print(f"\n❌ Error: {e}")
-        print("\nCheck application logs for details.")
-        raise
+    total = 0
+    for data_type in data_types:
+        count = totals.get(data_type, 0)
+        total += count
+        print(f"  ✅ {data_type.capitalize()}: {count} records captured")
+    print(f"\nTotal records captured to bronze: {total}")
+    print("=" * 70 + "\n")
+    logger.info("Bronze backfill completed", user_id=user_id, total_records=total)
+    return 0
 
 
 def main() -> None:
     """Main entry point."""
     args = parse_args()
 
-    # Determine start and end dates
-    start = None
-    end = None
-
-    if args.days:
-        # Calculate start date from days ago
-        start = datetime.now(timezone.utc) - timedelta(days=args.days)
-        logger.info(f"Backfilling last {args.days} days")
-
-    elif args.all:
-        # No start date = fetch all history
-        start = None
-        logger.info("Backfilling all available historical data")
-
-    elif args.start:
-        # Parse start date
+    # Resolve the date range.
+    now = datetime.now(timezone.utc)
+    if args.days is not None:
+        start, end = now - timedelta(days=args.days), now
+    else:
         start = parse_date(args.start)
+        end = parse_date(args.end) if args.end else now
 
-        # Parse end date if provided
-        if args.end:
-            end = parse_date(args.end)
+    if start > end:
+        print("Error: start date must be before end date")
+        sys.exit(1)
 
-        # Validate date range
-        if end and start > end:
-            print("Error: Start date must be before end date")
-            return
+    data_types = args.types or RANGE_DATA_TYPES
 
-    # Run backfill
+    # Bronze must be enabled, or there is nothing to write. Check before taking
+    # the lock so a misconfigured run fails instantly.
+    if not is_bronze_enabled():
+        print("\n❌ ERROR: bronze capture is disabled (BRONZE_ROOT not set).")
+        print("   Set BRONZE_ROOT (and mount a persistent volume there), then retry.\n")
+        sys.exit(1)
+
+    print("\n" + "=" * 70)
+    print("BRONZE BACKFILL")
+    print("=" * 70)
+    print(f"User ID:    {args.user_id}")
+    print(f"Start:      {start.strftime('%Y-%m-%d')}")
+    print(f"End:        {end.strftime('%Y-%m-%d')}")
+    print(f"Data Types: {', '.join(data_types)}")
+    print("=" * 70)
+    print("\n🔒 Acquiring sync lock (waiting for any in-flight poll to finish)...")
+
     try:
-        asyncio.run(
-            backfill_data(
-                user_id=args.user_id,
-                start=start,
-                end=end,
-                data_types=args.types,
+        # Hold the lock for the whole backfill so the poller skips its cycles.
+        # Acquired synchronously (outside the event loop) so the blocking wait
+        # never stalls async work.
+        with sync_lock(blocking=True):
+            print("🔄 Lock acquired. Starting backfill...\n")
+            exit_code = asyncio.run(
+                backfill_bronze(args.user_id, start, end, data_types)
             )
-        )
+    except SyncLockTimeout as e:
+        print(f"\n❌ ERROR: {e}")
+        print("   A poll/backfill is already running. Try again shortly.\n")
+        sys.exit(1)
     except KeyboardInterrupt:
         print("\n\nBackfill cancelled by user.")
-    except Exception as e:
-        print(f"\nBackfill failed: {e}")
-        exit(1)
+        sys.exit(130)
+
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -68,6 +68,16 @@ class Settings(BaseSettings):
     # Rate Limiting
     max_requests_per_minute: int = 60
 
+    # Cross-process sync coordination. The poller and an occasional `docker exec`
+    # backfill run in the SAME container and both call the rate-limited Whoop
+    # API; each process has its own in-memory rate limiter, so they must not run
+    # concurrently. An advisory file lock at sync_lock_path serializes them so
+    # only one hits the API at a time (see src/utils/sync_lock.py). The poller
+    # skips its cycle if the lock is held; a backfill waits up to
+    # sync_lock_timeout_seconds for an in-flight poll to finish.
+    sync_lock_path: str = "/tmp/whoop_sync.lock"
+    sync_lock_timeout_seconds: int = 300
+
     # Database connection pool (QueuePool). Each app instance keeps its own pool
     # (no external PgBouncer). pool_pre_ping is always on so a DB restart or idle
     # timeout is recovered transparently instead of erroring mid-query. Defaults

--- a/src/services/data_collector.py
+++ b/src/services/data_collector.py
@@ -17,6 +17,7 @@ from src.services.workout_service import WorkoutService
 from src.services.cycle_service import CycleService
 from src.services.body_measurement_service import BodyMeasurementService
 from src.utils.logging_config import get_logger
+from src.utils.sync_lock import sync_lock
 
 logger = get_logger(__name__)
 
@@ -341,9 +342,25 @@ async def sync_user_data(user_id: int) -> Dict[str, Any]:
     Returns:
         Sync results dictionary
     """
-    collector = DataCollector(user_id)
-    try:
-        return await collector.sync_all_data()
-    finally:
-        # Release pooled HTTP connections held for this sync run.
-        await collector.whoop_client.aclose()
+    # Serialize against an occasional `docker exec` backfill: both call the
+    # rate-limited Whoop API from separate processes with separate in-memory
+    # rate limiters, so they must not overlap. If a backfill holds the lock,
+    # skip this cycle rather than double up — the poller catches up next time.
+    with sync_lock(blocking=False) as acquired:
+        if not acquired:
+            logger.info(
+                "Sync lock held by another process (backfill?), skipping poll cycle",
+                user_id=user_id,
+            )
+            return {
+                "user_id": user_id,
+                "skipped": True,
+                "reason": "sync_lock_held",
+            }
+
+        collector = DataCollector(user_id)
+        try:
+            return await collector.sync_all_data()
+        finally:
+            # Release pooled HTTP connections held for this sync run.
+            await collector.whoop_client.aclose()

--- a/src/utils/sync_lock.py
+++ b/src/utils/sync_lock.py
@@ -1,0 +1,106 @@
+"""Cross-process serialization of Whoop API work via an advisory file lock.
+
+The app runs a long-lived poller and, occasionally, a ``docker exec`` backfill
+in the SAME container. Both call the rate-limited Whoop API, and each process
+keeps its OWN in-memory rate limiter -- so running them at once could exceed the
+API limit. We coordinate with a POSIX advisory lock (:func:`fcntl.flock`) on a
+shared file so only ONE process talks to the API at a time:
+
+* the poller takes the lock **non-blocking** and SKIPS its cycle if a backfill
+  holds it (it catches up on the next interval);
+* the backfill takes the lock **blocking** (bounded by a timeout) and runs to
+  completion while the poller skips.
+
+``flock`` is released automatically by the kernel when the holding process exits
+-- even on a crash or ``kill -9`` -- so there is no stale lock to clean up and
+no TTL to tune.
+"""
+
+import errno
+import fcntl
+import os
+import time
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from src.config import settings
+from src.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class SyncLockTimeout(Exception):
+    """Raised when a blocking lock acquisition exceeds its timeout."""
+
+
+def _try_acquire(fd: int) -> bool:
+    """Attempt a single non-blocking exclusive lock. True if acquired."""
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as exc:
+        # Lock held by someone else -> not an error, just "busy".
+        if exc.errno in (errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK):
+            return False
+        raise
+
+
+def _acquire_blocking(fd: int, timeout: int, poll_interval: float, path: str) -> None:
+    """Retry the non-blocking lock until acquired or the timeout elapses."""
+    deadline = time.monotonic() + max(0, timeout)
+    while not _try_acquire(fd):
+        if time.monotonic() >= deadline:
+            raise SyncLockTimeout(
+                f"could not acquire sync lock at {path} within {timeout}s"
+            )
+        time.sleep(poll_interval)
+
+
+@contextmanager
+def sync_lock(
+    *,
+    blocking: bool,
+    timeout: Optional[int] = None,
+    path: Optional[str] = None,
+    poll_interval: float = 1.0,
+) -> Iterator[bool]:
+    """Hold the shared Whoop-sync advisory lock for the duration of the context.
+
+    Args:
+        blocking: If True, wait (up to ``timeout`` seconds) for the lock. If
+            False, attempt once and yield immediately whether or not it was
+            acquired.
+        timeout: Max seconds to wait when ``blocking`` (defaults to
+            ``settings.sync_lock_timeout_seconds``). Ignored when non-blocking.
+        path: Lock file path (defaults to ``settings.sync_lock_path``).
+        poll_interval: Seconds between blocking retries.
+
+    Yields:
+        ``True`` if the lock is held inside the context, ``False`` otherwise
+        (only possible in non-blocking mode).
+
+    Raises:
+        SyncLockTimeout: In blocking mode, if the lock can't be acquired within
+            ``timeout`` seconds.
+    """
+    lock_path = path or settings.sync_lock_path
+    wait = settings.sync_lock_timeout_seconds if timeout is None else timeout
+
+    # The lock travels with the open file description, not the path, so we keep
+    # the fd open for the whole context and closing it releases the lock.
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    acquired = False
+    try:
+        if blocking:
+            _acquire_blocking(fd, wait, poll_interval, lock_path)
+            acquired = True
+        else:
+            acquired = _try_acquire(fd)
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:  # best-effort; closing the fd releases it anyway
+                pass
+        os.close(fd)

--- a/tests/unit/test_sync_lock.py
+++ b/tests/unit/test_sync_lock.py
@@ -1,0 +1,78 @@
+"""Tests for the cross-process advisory sync lock and poller participation."""
+
+import pytest
+
+from src.config import settings
+from src.utils.sync_lock import SyncLockTimeout, sync_lock
+
+
+@pytest.mark.unit
+class TestSyncLock:
+    """Tests for src.utils.sync_lock.sync_lock."""
+
+    def test_nonblocking_acquires_when_free(self, tmp_path):
+        lock_path = str(tmp_path / "lock")
+        with sync_lock(blocking=False, path=lock_path) as acquired:
+            assert acquired is True
+
+    def test_nonblocking_busy_when_held(self, tmp_path):
+        lock_path = str(tmp_path / "lock")
+        # A distinct open file description conflicts even within one process,
+        # so the inner non-blocking attempt must report busy.
+        with sync_lock(blocking=False, path=lock_path) as outer:
+            assert outer is True
+            with sync_lock(blocking=False, path=lock_path) as inner:
+                assert inner is False
+
+    def test_lock_released_on_exit(self, tmp_path):
+        lock_path = str(tmp_path / "lock")
+        with sync_lock(blocking=False, path=lock_path) as first:
+            assert first is True
+        # Once the context exits the lock is free again.
+        with sync_lock(blocking=False, path=lock_path) as second:
+            assert second is True
+
+    def test_blocking_times_out_when_held(self, tmp_path):
+        lock_path = str(tmp_path / "lock")
+        with sync_lock(blocking=False, path=lock_path) as outer:
+            assert outer is True
+            with pytest.raises(SyncLockTimeout):
+                with sync_lock(
+                    blocking=True, timeout=1, path=lock_path, poll_interval=0.05
+                ):
+                    pass
+
+    def test_blocking_acquires_after_release(self, tmp_path):
+        lock_path = str(tmp_path / "lock")
+        with sync_lock(blocking=False, path=lock_path):
+            pass
+        with sync_lock(
+            blocking=True, timeout=1, path=lock_path, poll_interval=0.05
+        ) as acquired:
+            assert acquired is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPollerLockParticipation:
+    """sync_user_data must skip a cycle when the lock is already held."""
+
+    async def test_skips_when_lock_held(self, tmp_path, monkeypatch):
+        lock_path = str(tmp_path / "lock")
+        monkeypatch.setattr(settings, "sync_lock_path", lock_path)
+
+        from src.services import data_collector as dc
+
+        # The poller must not even construct a collector when it can't get the lock.
+        def _boom(*args, **kwargs):
+            raise AssertionError("DataCollector should not run while lock is held")
+
+        monkeypatch.setattr(dc, "DataCollector", _boom)
+
+        with sync_lock(blocking=False, path=lock_path) as held:
+            assert held is True
+            result = await dc.sync_user_data(1)
+
+        assert result["skipped"] is True
+        assert result["reason"] == "sync_lock_held"
+        assert result["user_id"] == 1


### PR DESCRIPTION
## What & why

Adds an on-demand **bronze-only backfill** to true up gaps in bronze data between two dates, designed to run via `docker exec` against the already-running container (so it inherits the container's env vars and bronze volume mount).

The hard part isn't fetching a date range — that already existed — it's **not exceeding the Whoop API rate limit** while the regular poller is running in the same container. The rate limiter is in-memory **per process**, and a `docker exec` is a second process, so a naïve backfill could run two uncoordinated limiters and exceed 60/min.

## How

Serialize the poller and the backfill with a POSIX advisory file lock (`fcntl.flock`) so **only one process calls the Whoop API at a time** — then the existing per-process limiter is sufficient.

- **Backfill** takes the lock *blocking* (bounded by `sync_lock_timeout_seconds`), waits for any in-flight poll to finish, then holds it for the whole run.
- **Poller** takes the lock *non-blocking* and **skips that cycle** if a backfill holds it (it catches up next interval).
- The kernel releases `flock` automatically when the holding process exits — even on crash/`kill -9` — so there's **no stale lock** to clean up and no TTL to tune.

The backfill writes **bronze only** (no DB writes), aligning with the move toward bronze-only processing. It drives `WhoopClient.get_*_records()` over the range; raw pages are captured at the existing HTTP-client chokepoint.

## Changes

| File | Change |
|---|---|
| `src/utils/sync_lock.py` (new) | `flock` advisory-lock context manager (blocking + non-blocking) |
| `src/config.py` | `sync_lock_path` (default `/tmp/whoop_sync.lock`), `sync_lock_timeout_seconds` (300) |
| `src/services/data_collector.py` | `sync_user_data()` skips the cycle when the lock is held |
| `scripts/backfill_data.py` | repurposed to bronze-only, lock-serialized, non-interactive; range types only |
| `tests/unit/test_sync_lock.py` (new) | lock acquire/busy/release/timeout + poller-skip |
| `docs/BRONZE.md` | backfilling + rate-limit sections |

## Usage

```bash
docker exec whoopster-app python -m scripts.backfill_data --start 2025-12-17
docker exec whoopster-app python -m scripts.backfill_data --start 2025-12-17 --end 2026-01-15
docker exec whoopster-app python -m scripts.backfill_data --days 30 --types sleep recovery
```

Only range-based collections backfill (`sleep`, `recovery`, `workout`, `cycle`); `profile`/`body_measurement` are current-snapshot endpoints with no date range. If `BRONZE_ROOT` is unset the command exits with an error.

## ⚠️ Deployment prerequisite (outside this repo)

For the backfill **and** the live poller to actually write bronze, the running container must have:
- `BRONZE_ROOT` set (e.g. `/data/bronze`), and
- a **persistent volume mounted at that path**.

That's container/Ansible config, not part of this PR. Without it, bronze capture is a silent no-op (and the backfill will exit with the "bronze disabled" error).

`SYNC_LOCK_PATH` defaults to `/tmp/whoop_sync.lock`; both the poller and the `exec`'d backfill must resolve the **same** path (they do, since `exec` inherits the container env).

## Testing

- 166 unit tests pass (6 new). `data_collector` and `sync_lock` covered.
- Smoke-tested the script's arg parsing, bronze-disabled fast-exit, and bad-range rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)